### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
     - package-ecosystem: "npm"
       directory: "/"
       schedule:
-          interval: "weekly"
+          interval: "daily"
+      open-pull-requests-limit: 2
 
     # Enable version updates for github actions
     - package-ecosystem: "github-actions"


### PR DESCRIPTION
Daily updates, but with a smaller PR limit

This just saves Vercel from building billions of previews when a dependabot update comes in