### PR TITLE
Add QR code toggle to the control pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "next": "16.2.6",
                 "react": "19.2.0",
                 "react-dom": "19.2.0",
+                "react-qr-code": "^2.0.21",
                 "react-transition-group": "^4.4.5",
                 "swr": "^2.3.0"
             },
@@ -9829,6 +9830,12 @@
                 }
             ]
         },
+        "node_modules/qr.js": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+            "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+            "license": "MIT"
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9875,6 +9882,19 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "node_modules/react-qr-code": {
+            "version": "2.0.21",
+            "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.21.tgz",
+            "integrity": "sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "prop-types": "^15.8.1",
+                "qr.js": "0.0.0"
+            },
+            "peerDependencies": {
+                "react": "*"
+            }
         },
         "node_modules/react-transition-group": {
             "version": "4.4.5",
@@ -18292,6 +18312,11 @@
             "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
             "dev": true
         },
+        "qr.js": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+            "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+        },
         "queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -18315,6 +18340,15 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-qr-code": {
+            "version": "2.0.21",
+            "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.21.tgz",
+            "integrity": "sha512-xaywjo0eaF4S3LOz6ns5eoPbM2E+q9HYl4VATYpxK4bBniOhQ9noY2RJ9G4SnZFhUwzx63FUT6KdHzfKgUwyuQ==",
+            "requires": {
+                "prop-types": "^15.8.1",
+                "qr.js": "0.0.0"
+            }
         },
         "react-transition-group": {
             "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "next": "16.2.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",
+        "react-qr-code": "^2.0.21",
         "react-transition-group": "^4.4.5",
         "swr": "^2.3.0"
     },

--- a/src/components/ControlTools.tsx
+++ b/src/components/ControlTools.tsx
@@ -10,6 +10,7 @@ import { faFastForward } from "@fortawesome/free-solid-svg-icons/faFastForward";
 import { faPause } from "@fortawesome/free-solid-svg-icons/faPause";
 import { faPlay } from "@fortawesome/free-solid-svg-icons/faPlay";
 import React, { useState } from "react";
+import QRCode from "react-qr-code";
 import { ApiResponseDecode } from "@fc/types/io-ts-def";
 import { ControlComponentMapper } from "@fc/lib/ComponentMapper";
 
@@ -169,6 +170,12 @@ export default function ControlTools({
         });
 
     const [error, setError] = useState<string>();
+    const [showQR, setShowQR] = useState<boolean>(false);
+    const [playerUrl] = useState<string>(() =>
+        typeof window !== "undefined"
+            ? `${window.location.origin}/game/${game._id}`
+            : "",
+    );
 
     return (
         <div className="first-contact-container py-4 lg:p-4 lg:bg-linear-to-b from-turn-counter-past-light to-turn-counter-past-dark">
@@ -189,6 +196,26 @@ export default function ControlTools({
                         />
                     );
                 })}
+            </div>
+            <div className="flex flex-col items-center w-full p-4">
+                <button
+                    type="button"
+                    className="bg-turn-counter-future border-black hover:bg-turn-counter-current hover:border-yellow-300 border-4 rounded-sm p-2 px-4"
+                    onClick={() => setShowQR((prev) => !prev)}
+                    aria-expanded={showQR}
+                >
+                    {showQR ? "Hide QR code" : "Show QR code"}
+                </button>
+                {showQR && playerUrl !== "" ? (
+                    <div className="mt-4 max-w-xs mx-auto flex flex-col items-center">
+                        <div className="bg-white p-4">
+                            <QRCode value={playerUrl} />
+                        </div>
+                        <code className="mt-2 bg-black text-white px-2 py-1 text-sm break-all text-center">
+                            {playerUrl}
+                        </code>
+                    </div>
+                ) : null}
             </div>
             <div className="flex w-full p-4 justify-around">
                 {error !== undefined ? (


### PR DESCRIPTION
## Summary
- Adds a "Show QR code" toggle below the playback controls on the control pane (`/game/{id}/control`)
- When toggled on, renders an SVG QR code linking to the player view (`/game/{id}`) plus the encoded URL as selectable text, so operators no longer need to generate one externally
- Adds `react-qr-code` (~10KB SVG-only) as a runtime dependency

## Test plan
- [ ] Navigate to `/game/{id}/control` for any existing game
- [ ] Existing control buttons (back/forward/play/pause) still render and function
- [ ] Click "Show QR code" → QR code appears on white background with the absolute player URL beneath it
- [ ] Scan the QR with a phone → opens the player view
- [ ] Click again to hide