### PR TITLE
Raise Dependabot npm PR limit to 5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
       directory: "/"
       schedule:
           interval: "daily"
-      open-pull-requests-limit: 2
+      open-pull-requests-limit: 5
 
     # Enable version updates for github actions
     - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Bumps `open-pull-requests-limit` for the npm ecosystem from 2 to 5 so more dependency updates can queue up at once.

## Test plan
- [ ] Confirm Dependabot opens additional PRs on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)