### PR TITLE
Tighten Dependabot config and fix argon2 postinstall on npm 11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,16 @@ updates:
       schedule:
           interval: "daily"
       open-pull-requests-limit: 5
+      groups:
+          react:
+              patterns:
+                  - "react"
+                  - "react-dom"
+                  - "@types/react"
+                  - "@types/react-dom"
+          fontawesome:
+              patterns:
+                  - "@fortawesome/*"
 
     # Enable version updates for github actions
     - package-ecosystem: "github-actions"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+strict-peer-deps=true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "create-user": "tsx src/bin/create-user.ts",
         "prepare": "husky",
         "test": "jest",
-        "postinstall": "npm rebuild argon2 -- --build-from-source"
+        "postinstall": "npm rebuild argon2 --build-from-source"
     },
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.2.0",


### PR DESCRIPTION
## Summary
- Enable `strict-peer-deps=true` so `npm ci` fails loud on peer mismatches instead of silently installing an unsupported tree (e.g. ESLint v10 against eslint-config-next plugins that peer-require ^9).
- Group related Dependabot updates so react/react-dom/@types/react/@types/react-dom always bump together (Next.js refuses to build with mismatched react/react-dom), and `@fortawesome/*` releases bundle into a single PR.
- Fix the argon2 postinstall script for npm 11 — the `--` separator in `npm rebuild argon2 -- --build-from-source` now raises `only supports SemVer version/range specifiers`. Dropping the `--` works on both npm 10 (current CI) and npm 11 (current local default for Node 24+). Verified locally that source build still happens (CC/CXX compilation visible).

## Test plan
- [ ] CI passes on this branch
- [ ] Wait for next Dependabot run and confirm react / fontawesome PRs are grouped
- [ ] Note: npm 11 prints a deprecation warning for `--build-from-source`; functionally fine today but worth tracking — npm 12 is likely to drop the flag, at which point a more durable replacement (invoke node-pre-gyp directly, or pin Node/npm) will be needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)