### PR TITLE
Add optional turn limit to games

### DIFF
--- a/__test__/server/turn/hasFinished.test.ts
+++ b/__test__/server/turn/hasFinished.test.ts
@@ -92,6 +92,52 @@ describe("hasfinished", () => {
     });
 
     testCases.forEach(({ name, difference }) => {
+        test(`${name} - at the turn limit forced to false`, () => {
+            const newDate = new Date(
+                mockCurrentDate.getTime() + difference * 1000,
+            );
+            const game: Game = {
+                ...baseGame,
+                setupInformation: {
+                    ...baseGame.setupInformation,
+                    phases: [{ title: "test", length: 1, hidden: false }],
+                    maxTurns: 8,
+                },
+                turnInformation: {
+                    turnNumber: 8,
+                    currentPhase: 1,
+                    phaseEnd: newDate.toString(),
+                },
+            };
+
+            expect(hasFinished(game)).toBe(false);
+        });
+    });
+
+    testCases.forEach(({ name, difference, expected }) => {
+        test(`${name} - below the turn limit behaves normally (${expected})`, () => {
+            const newDate = new Date(
+                mockCurrentDate.getTime() + difference * 1000,
+            );
+            const game: Game = {
+                ...baseGame,
+                setupInformation: {
+                    ...baseGame.setupInformation,
+                    phases: [{ title: "test", length: 1, hidden: false }],
+                    maxTurns: 8,
+                },
+                turnInformation: {
+                    turnNumber: 7,
+                    currentPhase: 1,
+                    phaseEnd: newDate.toString(),
+                },
+            };
+
+            expect(hasFinished(game)).toBe(expected);
+        });
+    });
+
+    testCases.forEach(({ name, difference }) => {
         test(`${name} - when inactive forced to false`, () => {
             const newDate = new Date(
                 mockCurrentDate.getTime() + difference * 1000,

--- a/__test__/server/turn/isAtTurnLimit.test.ts
+++ b/__test__/server/turn/isAtTurnLimit.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "@jest/globals";
+import { setupInformation, testPhases } from "./helpers";
+import { Game } from "@fc/types/types";
+import { atTurnLimit, isAtTurnLimit } from "@fc/server/turn";
+
+describe("atTurnLimit", () => {
+    const setupWithLimit = {
+        ...setupInformation,
+        phases: testPhases,
+        maxTurns: 3,
+    };
+
+    test("no maxTurns set - always false", () => {
+        const setup = { ...setupInformation, phases: testPhases };
+
+        for (let turn = 1; turn <= 10; turn++) {
+            for (let phase = 1; phase <= testPhases.length; phase++) {
+                expect(atTurnLimit(turn, phase, setup)).toBe(false);
+            }
+        }
+    });
+
+    const testCases: {
+        name: string;
+        turn: number;
+        phase: number;
+        expected: boolean;
+    }[] = [
+        {
+            name: "below final turn, first phase",
+            turn: 1,
+            phase: 1,
+            expected: false,
+        },
+        {
+            name: "below final turn, last phase",
+            turn: 2,
+            phase: testPhases.length,
+            expected: false,
+        },
+        {
+            name: "final turn, first phase",
+            turn: 3,
+            phase: 1,
+            expected: false,
+        },
+        {
+            name: "final turn, middle phase",
+            turn: 3,
+            phase: 2,
+            expected: false,
+        },
+        {
+            name: "final turn, last phase",
+            turn: 3,
+            phase: testPhases.length,
+            expected: true,
+        },
+        {
+            name: "past final turn, last phase",
+            turn: 4,
+            phase: testPhases.length,
+            expected: true,
+        },
+    ];
+
+    testCases.forEach(({ name, turn, phase, expected }) => {
+        test(`${name} - ${expected}`, () => {
+            expect(atTurnLimit(turn, phase, setupWithLimit)).toBe(expected);
+        });
+    });
+
+    testCases.forEach(({ name, turn, phase, expected }) => {
+        test(`isAtTurnLimit: ${name} - ${expected}`, () => {
+            const game: Game = {
+                _id: "TEST",
+                setupInformation: setupWithLimit,
+                turnInformation: {
+                    turnNumber: turn,
+                    currentPhase: phase,
+                    phaseEnd: "TEST",
+                },
+                components: [],
+                active: true,
+                breakingNews: [],
+            };
+
+            expect(isAtTurnLimit(game)).toBe(expected);
+        });
+    });
+});

--- a/__test__/server/turn/tickTurn.test.ts
+++ b/__test__/server/turn/tickTurn.test.ts
@@ -86,6 +86,41 @@ describe("tickTurn", () => {
 
                 expect(tickTurn(baseGame)).toEqual(expectedGame);
             });
+
+            test(`last phase of the final turn does not tick when maxTurns is ${currentTurn}`, () => {
+                const game: Game = {
+                    ...baseGame,
+                    setupInformation: {
+                        ...baseGame.setupInformation,
+                        maxTurns: currentTurn,
+                    },
+                };
+
+                expect(tickTurn(game)).toEqual(game);
+            });
+
+            test(`last phase still ticks to turn ${
+                currentTurn + 1
+            } when maxTurns is ${currentTurn + 1}`, () => {
+                const game: Game = {
+                    ...baseGame,
+                    setupInformation: {
+                        ...baseGame.setupInformation,
+                        maxTurns: currentTurn + 1,
+                    },
+                };
+
+                const expectedGame = {
+                    ...game,
+                    turnInformation: {
+                        turnNumber: currentTurn + 1,
+                        currentPhase: 1,
+                        phaseEnd: new Date(60 * 1000).toString(),
+                    },
+                };
+
+                expect(tickTurn(game)).toEqual(expectedGame);
+            });
         }
     }
 });

--- a/src/app/admin/game/create/api/route.ts
+++ b/src/app/admin/game/create/api/route.ts
@@ -279,6 +279,7 @@ const GAME_TYPES: Record<
             breakingNewsBanner: true,
             components: [],
             logo: "/dow-new-eden.png",
+            maxTurns: 8,
             press: {
                 name: "INC",
                 logo: "/inc.png",
@@ -361,6 +362,7 @@ const GAME_TYPES: Record<
             theme: "first-contact",
             breakingNewsBanner: true,
             components: [],
+            maxTurns: 8,
             press: [
                 {
                     name: "Test Press",

--- a/src/app/game/[id]/control/api/route.ts
+++ b/src/app/game/[id]/control/api/route.ts
@@ -3,7 +3,11 @@ import { ApiResponse, ControlAction, ControlAPI, Game } from "@fc/types/types";
 import { isLeft } from "fp-ts/Either";
 import { getGameRepo } from "@fc/server/repository/game";
 import { ControlAPIDecode } from "@fc/types/io-ts-def";
-import { generateNewTurnInformation, toApiResponse } from "@fc/server/turn";
+import {
+    generateNewTurnInformation,
+    isAtTurnLimit,
+    toApiResponse,
+} from "@fc/server/turn";
 import { MakeRight } from "@fc/lib/io-ts-helpers";
 
 const CONTROL_ACTIONS: Record<ControlAPI["action"], ControlAction> = {
@@ -85,6 +89,10 @@ const CONTROL_ACTIONS: Record<ControlAPI["action"], ControlAction> = {
         });
     },
     "forward-phase": (game) => {
+        if (isAtTurnLimit(game)) {
+            return MakeRight(game);
+        }
+
         const turnInformation = game.turnInformation;
 
         const { newPhase, turnNumber } =
@@ -113,7 +121,10 @@ const CONTROL_ACTIONS: Record<ControlAPI["action"], ControlAction> = {
         const turnInformation = game.turnInformation;
 
         const newPhase = 1;
-        const turnNumber = turnInformation.turnNumber + 1;
+        const turnNumber = Math.min(
+            turnInformation.turnNumber + 1,
+            game.setupInformation.maxTurns ?? Infinity,
+        );
 
         const newTurnInformation = generateNewTurnInformation(
             newPhase,

--- a/src/components/theme/aftermath/TurnCounter.tsx
+++ b/src/components/theme/aftermath/TurnCounter.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Game, SetupInformation } from "@fc/types/types";
+import { atTurnLimit } from "@fc/server/turn";
 import { TurnComponentMapper } from "@fc/lib/ComponentMapper";
 
 type TurnCounterProps = {
@@ -15,23 +16,32 @@ const TurnTimer = function TurnTimer(props: {
     timestamp: number;
     active: boolean;
     mobile: boolean;
+    finished: boolean;
 }) {
     const formatter = new Intl.NumberFormat("en-GB", {
         minimumIntegerDigits: 2,
     });
 
-    const { timestamp, active, mobile } = props;
+    const { timestamp, active, mobile, finished } = props;
     const minutes = Math.floor(Number(timestamp / 60));
     const seconds = timestamp % 60;
 
     let paused;
 
-    if (!active) {
-        const pausedClass = mobile ? "lg:hidden" : "hidden lg:block";
+    const bannerClass = mobile ? "lg:hidden" : "hidden lg:block";
 
+    if (finished) {
         paused = (
             <p
-                className={`${pausedClass} pt-10 px-6 bg-zinc-600 text-white rounded-sm alert alert-danger text-6xl`}
+                className={`${bannerClass} pt-10 px-6 bg-zinc-600 text-white rounded-sm alert alert-danger text-6xl`}
+            >
+                GAME COMPLETE
+            </p>
+        );
+    } else if (!active) {
+        paused = (
+            <p
+                className={`${bannerClass} pt-10 px-6 bg-zinc-600 text-white rounded-sm alert alert-danger text-6xl`}
             >
                 GAME PAUSED
             </p>
@@ -95,6 +105,12 @@ export default function TurnCounter(props: TurnCounterProps) {
     const textSize = setupInformation.phases[phase - 1]?.hidden
         ? "text-4xl lg:text-5xl"
         : "text-6xl lg:text-8xl";
+    const turnText =
+        setupInformation.maxTurns === undefined
+            ? `Aftermath Turn ${turn}`
+            : `Aftermath Turn ${turn} of ${setupInformation.maxTurns}`;
+    const finished =
+        atTurnLimit(turn, phase, setupInformation) && timestamp === 0;
 
     return (
         <React.Fragment>
@@ -107,7 +123,7 @@ export default function TurnCounter(props: TurnCounterProps) {
                 ))}
                 <div>
                     <h1 className="text-3xl lg:text-4xl mt-4 mb-4 lg:mb-8 uppercase ">
-                        Aftermath Turn {turn}
+                        {turnText}
                     </h1>
                     <h2
                         className={`font-semibold mt-4 mb-4 uppercase w-7/8 m-auto ${textSize}`}
@@ -118,11 +134,13 @@ export default function TurnCounter(props: TurnCounterProps) {
                         timestamp={timestamp}
                         active={active}
                         mobile={true}
+                        finished={finished}
                     />
                     <TurnTimer
                         timestamp={timestamp}
                         active={active}
                         mobile={false}
+                        finished={finished}
                     />
                 </div>
             </div>

--- a/src/components/theme/first-contact/TurnCounter.tsx
+++ b/src/components/theme/first-contact/TurnCounter.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Game, SetupInformation } from "@fc/types/types";
-import { lengthOfPhase } from "@fc/server/turn";
+import { atTurnLimit, lengthOfPhase } from "@fc/server/turn";
 import { isLeft } from "fp-ts/Either";
 import { TurnComponentMapper } from "@fc/lib/ComponentMapper";
 import Image from "next/image";
@@ -18,23 +18,32 @@ const TurnTimer = function TurnTimer(props: {
     timestamp: number;
     active: boolean;
     mobile: boolean;
+    finished: boolean;
 }) {
     const formatter = new Intl.NumberFormat("en-GB", {
         minimumIntegerDigits: 2,
     });
 
-    const { timestamp, active, mobile } = props;
+    const { timestamp, active, mobile, finished } = props;
     const minutes = Math.floor(Number(timestamp / 60));
     const seconds = timestamp % 60;
 
     let paused;
 
-    if (!active) {
-        const pausedClass = mobile ? "lg:hidden" : "hidden lg:block";
+    const bannerClass = mobile ? "lg:hidden" : "hidden lg:block";
 
+    if (finished) {
         paused = (
             <p
-                className={`${pausedClass} py-3 px-6 bg-zinc-600 text-white rounded-sm alert alert-danger text-3xl`}
+                className={`${bannerClass} py-3 px-6 bg-zinc-600 text-white rounded-sm alert alert-danger text-3xl`}
+            >
+                GAME COMPLETE
+            </p>
+        );
+    } else if (!active) {
+        paused = (
+            <p
+                className={`${bannerClass} py-3 px-6 bg-zinc-600 text-white rounded-sm alert alert-danger text-3xl`}
             >
                 GAME PAUSED
             </p>
@@ -139,6 +148,12 @@ export default function TurnCounter(props: TurnCounterProps) {
     const { turn, phase, timestamp, active, setupInformation } = props;
 
     const text = setupInformation.phases[phase - 1]?.title;
+    const turnText =
+        setupInformation.maxTurns === undefined
+            ? `Turn ${turn}`
+            : `Turn ${turn} of ${setupInformation.maxTurns}`;
+    const finished =
+        atTurnLimit(turn, phase, setupInformation) && timestamp === 0;
 
     return (
         <React.Fragment>
@@ -149,9 +164,14 @@ export default function TurnCounter(props: TurnCounterProps) {
                 <TurnComponentMapper key={key} component={component} />
             ))}
             <h1 className="text-4xl lg:text-5xl mt-4 mb-8 uppercase ">
-                Turn {turn}: {text}
+                {turnText}: {text}
             </h1>
-            <TurnTimer timestamp={timestamp} active={active} mobile={true} />
+            <TurnTimer
+                timestamp={timestamp}
+                active={active}
+                mobile={true}
+                finished={finished}
+            />
             <div className="flex lg:flex-wrap flex-row  mt-4">
                 {setupInformation.phases.map((val, key) => {
                     const phaseLength = lengthOfPhase(
@@ -175,7 +195,12 @@ export default function TurnCounter(props: TurnCounterProps) {
                     );
                 })}
             </div>
-            <TurnTimer timestamp={timestamp} active={active} mobile={false} />
+            <TurnTimer
+                timestamp={timestamp}
+                active={active}
+                mobile={false}
+                finished={finished}
+            />
         </React.Fragment>
     );
 }

--- a/src/server/turn.ts
+++ b/src/server/turn.ts
@@ -91,7 +91,33 @@ export function nextPhase(phase: number, setup: SetupInformation): number {
     return newPhaseNumber > setup.phases.length ? 1 : newPhaseNumber;
 }
 
+export function atTurnLimit(
+    turnNumber: number,
+    currentPhase: number,
+    setupInformation: SetupInformation,
+): boolean {
+    const maxTurns = setupInformation.maxTurns;
+
+    return (
+        maxTurns !== undefined &&
+        turnNumber >= maxTurns &&
+        currentPhase >= setupInformation.phases.length
+    );
+}
+
+export function isAtTurnLimit(game: Game): boolean {
+    return atTurnLimit(
+        game.turnInformation.turnNumber,
+        game.turnInformation.currentPhase,
+        game.setupInformation,
+    );
+}
+
 export function tickTurn(game: Game): Game {
+    if (isAtTurnLimit(game)) {
+        return game;
+    }
+
     const newPhase: number = nextPhase(
         game.turnInformation.currentPhase,
         game.setupInformation,
@@ -119,7 +145,11 @@ export function tickTurn(game: Game): Game {
 }
 
 export function hasFinished(game: Game): boolean {
-    return game.active && new Date(game.turnInformation.phaseEnd) < new Date();
+    return (
+        game.active &&
+        !isAtTurnLimit(game) &&
+        new Date(game.turnInformation.phaseEnd) < new Date()
+    );
 }
 
 export function createGame(

--- a/src/types/io-ts-def.ts
+++ b/src/types/io-ts-def.ts
@@ -250,6 +250,9 @@ export const SetupInformationDecode = t.intersection([
         hidePressInSidebar: t.boolean,
     }),
     t.partial({
+        maxTurns: t.number,
+    }),
+    t.partial({
         timerStyles: t.type({
             activePhase: PhaseStyleDecode,
             futurePhase: PhaseStyleDecode,


### PR DESCRIPTION
## Summary

Games can now declare a fixed number of turns via an optional `maxTurns` field in their setup information. **Den of Wolves: New Eden** (and the dev test game) are capped at 8 turns.

## Design

"Finished" is **derived, never stored**: a game is complete when it's on the last phase of turn `maxTurns` and the timer has elapsed. No new persisted state, no migration — and rewinding with back-turn naturally un-finishes the game, which is handy at a live event.

- `SetupInformationDecode` gains optional `maxTurns` — existing games decode unchanged and behave exactly as before.
- `hasFinished()` returns false at the limit, so the auto-tick never fires and the timer parks at 00:00. `tickTurn()` is also a no-op at the limit as defence in depth.
- GM controls: `forward-phase` no-ops at the limit; `forward-turn` clamps to `maxTurns`. Backward controls untouched.
- UI (both themes): heading shows "Turn 3 of 8" when a limit is set, and a **GAME COMPLETE** banner (same styling as GAME PAUSED) shows when the final phase runs out.

## Testing

- New `isAtTurnLimit.test.ts` plus turn-limit cases in `tickTurn.test.ts` and `hasFinished.test.ts` (~50 new tests, following the existing table style).
- Full suite passes: 326 tests / 13 suites; `tsc --noEmit` clean.

To try it on staging: create a `dev-test-game` (or a DoW: New Eden game) and use forward-turn to reach turn 8, then let the last phase run out — the timer should stop at 00:00 with GAME COMPLETE, and forward controls should refuse to go past turn 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)