### PR TITLE
Fix mobile tab-switch crash (scrollTo effect returned a Promise)

### DIFF
--- a/src/components/TabSwitcher.tsx
+++ b/src/components/TabSwitcher.tsx
@@ -18,7 +18,9 @@ export function GameTabSwitcher({
     manageTabTitle: string | null;
     game: Game;
 }) {
-    useEffect(() => window.scrollTo({ top: 0 }), [activeTab]);
+    useEffect(() => {
+        window.scrollTo({ top: 0 });
+    }, [activeTab]);
 
     const tabs: Record<string, TabInfo> = {
         home: {


### PR DESCRIPTION
## Problem

On mobile, tapping a bottom-bar tab on the game page crashed with
`TypeError: i is not a function` (inside React's `commitHookEffectListUnmount`).
Reproducible on-device but not on desktop.

## Root cause

`GameTabSwitcher`'s scroll-to-top effect used an implicit-return arrow:

```js
useEffect(() => window.scrollTo({ top: 0 }), [activeTab]);
```

On mobile browsers `window.scrollTo({...})` returns a **Promise**, so the
effect's return value — which React treats as the cleanup function — became a
Promise. On the next tab change React invoked that Promise as `destroy()`
during effect teardown → `i is not a function`.

Desktop was unaffected because the bottom `GameTabSwitcher` bar is `lg:hidden`;
on a laptop you switch tabs via the sidebar instead. Hence "mobile only".

## Fix

Give the effect a block body so it returns `undefined`. Verified against a
local dev build (React dev warning gone; tapping through all tabs produces no
console/page errors).

## Notes

- Follow-ups (tracked separately): decide whether to drop `react-transition-group`
  (unsupported on React 19), and add an e2e mobile-viewport tab-switch smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)