### PR TITLE
Fix prototype pollution in control component update handlers

### DIFF
--- a/__test__/app/game/control/defcon.test.ts
+++ b/__test__/app/game/control/defcon.test.ts
@@ -193,4 +193,29 @@ describe("POST /game/[id]/control/api/defcon", () => {
         expect(body.active).toBe(false);
         expect(body.components[0].countries.China.status).toBe(2);
     });
+
+    describe.each(["__proto__", "constructor", "prototype"])(
+        "rejects the prototype-polluting state name %p",
+        (stateName) => {
+            test("returns a 500 and does not pollute Object.prototype", async () => {
+                const repo = makeFakeGameRepo(
+                    makeActiveGame({ components: [defconComponent()] }),
+                );
+                getGameRepo.mockReturnValue(MakeRight(repo));
+
+                const response = await POST(
+                    makeRequest({ stateName, newStatus: 1 }),
+                    makeProps(),
+                );
+
+                expect(response.status).toBe(500);
+                expect(await response.json()).toEqual({
+                    error: `Defcon component does not include ${stateName}`,
+                });
+                // Had the inherited-key lookup passed the guard, the write
+                // would have landed on Object.prototype.status.
+                expect(({} as Record<string, unknown>).status).toBeUndefined();
+            });
+        },
+    );
 });

--- a/__test__/app/game/control/runnerrep.test.ts
+++ b/__test__/app/game/control/runnerrep.test.ts
@@ -190,4 +190,31 @@ describe("POST /game/[id]/control/api/runnerrep", () => {
         expect(body.active).toBe(false);
         expect(body.components[0].rep.Ballet.reputation).toBe(5);
     });
+
+    describe.each(["__proto__", "constructor", "prototype"])(
+        "rejects the prototype-polluting runner name %p",
+        (runnerName) => {
+            test("returns a 500 and does not pollute Object.prototype", async () => {
+                const repo = makeFakeGameRepo(
+                    makeActiveGame({ components: [runnersComponent()] }),
+                );
+                getGameRepo.mockReturnValue(MakeRight(repo));
+
+                const response = await POST(
+                    makeRequest({ runnerName, diff: 1 }),
+                    makeProps(),
+                );
+
+                expect(response.status).toBe(500);
+                expect(await response.json()).toEqual({
+                    error: `No ${runnerName} runner found for game test-game`,
+                });
+                // Had the inherited-key lookup passed the guard, the write
+                // would have landed on Object.prototype.reputation.
+                expect(
+                    ({} as Record<string, unknown>).reputation,
+                ).toBeUndefined();
+            });
+        },
+    );
 });

--- a/__test__/app/game/control/trackers.test.ts
+++ b/__test__/app/game/control/trackers.test.ts
@@ -308,4 +308,52 @@ describe("POST /game/[id]/control/api/trackers", () => {
             expect(body.components[0].trackers).toEqual({});
         });
     });
+
+    describe("prototype pollution", () => {
+        test.each(["__proto__", "constructor", "prototype"])(
+            "setting the tracker %p returns a 500 and does not pollute Object.prototype",
+            async (tracker) => {
+                const repo = makeFakeGameRepo(
+                    makeActiveGame({ components: [trackersComponent()] }),
+                );
+                getGameRepo.mockReturnValue(MakeRight(repo));
+
+                const response = await POST(
+                    makeRequest({ tracker, value: 7 }),
+                    makeProps(),
+                );
+
+                expect(response.status).toBe(500);
+                expect(await response.json()).toEqual({
+                    error: `No ${tracker} tracker found for game test-game`,
+                });
+                // Had the inherited-key lookup passed the guard, the write
+                // would have landed on Object.prototype.value.
+                expect(({} as Record<string, unknown>).value).toBeUndefined();
+            },
+        );
+
+        test.each(["__proto__", "constructor", "prototype"])(
+            "adding the tracker %p is rejected as an invalid name",
+            async (tracker) => {
+                const repo = makeFakeGameRepo(
+                    makeActiveGame({ components: [trackersComponent()] }),
+                );
+                getGameRepo.mockReturnValue(MakeRight(repo));
+
+                const response = await POST(
+                    makeRequest({
+                        tracker,
+                        trackerDefinition: { value: 0, type: "circle", max: 5 },
+                    }),
+                    makeProps(),
+                );
+
+                expect(response.status).toBe(500);
+                expect(await response.json()).toEqual({
+                    error: `${tracker} is not a valid tracker name for game test-game`,
+                });
+            },
+        );
+    });
 });

--- a/src/app/game/[id]/control/api/defcon/route.ts
+++ b/src/app/game/[id]/control/api/defcon/route.ts
@@ -48,9 +48,7 @@ export async function POST(
                 return MakeLeft(`No defcon component for game ${id}`);
             }
 
-            const country = defconComponent.countries[body.stateName];
-
-            if (!country) {
+            if (!Object.hasOwn(defconComponent.countries, body.stateName)) {
                 return MakeLeft(
                     `Defcon component does not include ${body.stateName}`,
                 );

--- a/src/app/game/[id]/control/api/runnerrep/route.ts
+++ b/src/app/game/[id]/control/api/runnerrep/route.ts
@@ -50,7 +50,7 @@ export async function POST(
                 );
             }
 
-            if (corpComponent.rep[body.runnerName] === undefined) {
+            if (!Object.hasOwn(corpComponent.rep, body.runnerName)) {
                 return MakeLeft(
                     `No ${body.runnerName} runner found for game ${id}`,
                 );

--- a/src/app/game/[id]/control/api/trackers/route.ts
+++ b/src/app/game/[id]/control/api/trackers/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@fc/types/io-ts-def";
 import { toApiResponse } from "@fc/server/turn";
 import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
+import { isUnsafeKey } from "@fc/lib/safe-keys";
 
 async function AddTrackerAction(
     body: AddTracker,
@@ -35,7 +36,13 @@ async function AddTrackerAction(
             );
         }
 
-        if (tracker.trackers[body.tracker] !== undefined) {
+        if (isUnsafeKey(body.tracker)) {
+            return MakeLeft(
+                `${body.tracker} is not a valid tracker name for game ${game._id}`,
+            );
+        }
+
+        if (Object.hasOwn(tracker.trackers, body.tracker)) {
             return MakeLeft(
                 `${body.tracker} tracker already exists for game ${game._id}`,
             );
@@ -87,7 +94,7 @@ async function SetTrackerAction(
             );
         }
 
-        if (tracker.trackers[body.tracker] === undefined) {
+        if (!Object.hasOwn(tracker.trackers, body.tracker)) {
             return MakeLeft(
                 `No ${body.tracker} tracker found for game ${game._id}`,
             );
@@ -133,7 +140,7 @@ async function DeleteTrackerAction(
             );
         }
 
-        if (tracker.trackers[body.tracker] === undefined) {
+        if (!Object.hasOwn(tracker.trackers, body.tracker)) {
             return MakeLeft(
                 `No ${body.tracker} tracker found for game ${game._id}`,
             );

--- a/src/lib/safe-keys.ts
+++ b/src/lib/safe-keys.ts
@@ -1,0 +1,19 @@
+/**
+ * Keys which, if used to create a property on a plain object, can tamper with
+ * the prototype chain (prototype pollution). Client-supplied strings that end
+ * up as object keys must be rejected if they match one of these.
+ *
+ * Note: for *looking up* an existing entry, prefer `Object.hasOwn`, which
+ * rejects every inherited key (including `toString`, `valueOf`, ...), not just
+ * the ones listed here. `isUnsafeKey` is for the create path, where the key is
+ * expected to be absent and `Object.hasOwn` would therefore let it through.
+ */
+const UNSAFE_KEYS: ReadonlySet<string> = new Set([
+    "__proto__",
+    "constructor",
+    "prototype",
+]);
+
+export function isUnsafeKey(key: string): boolean {
+    return UNSAFE_KEYS.has(key);
+}


### PR DESCRIPTION
## Problem

Three control API handlers index a component object with an unvalidated, client-supplied string, guarded only by an existence check that is **truthy for inherited keys**:

| Handler | Field (unconstrained `t.string`) | Vulnerable write |
| --- | --- | --- |
| `defcon/route.ts` | `stateName` | `defconComponent.countries[stateName].status = …` |
| `trackers/route.ts` (SetTracker) | `tracker` | `tracker.trackers[tracker].value = …` |
| `runnerrep/route.ts` | `runnerName` | `corpComponent.rep[runnerName].reputation = …` |

For example, `countries["__proto__"]` returns `Object.prototype` (not `undefined`), so the `if (!country)` / `=== undefined` guard passes and the subsequent write lands on **`Object.prototype`**, polluting the prototype for the running server process and potentially corrupting later request handling.

Example request:

```
POST /game/<id>/control/api/defcon
{"stateName":"__proto__","newStatus":1}
```

Old behaviour: `200 OK` and `Object.prototype.status` is now `1`.

## Fix

- Replace the existence guards with **`Object.hasOwn`**, which rejects *every* inherited key (`__proto__`, `constructor`, `prototype`, `toString`, …) rather than only checking for `undefined`. Applied to the defcon, tracker set, tracker delete, and runnerrep guards.
- On the tracker **create** path, an absent key is the expected/pass case, so `Object.hasOwn` alone offers no protection there. Added a small `isUnsafeKey` helper (`src/lib/safe-keys.ts`) and reject `__proto__`/`constructor`/`prototype` names explicitly before creating the key.

Rejected requests now return the handler's normal `500` "not found" / "not a valid name" error instead of silently mutating the prototype.

## Tests

Added regression tests to all three handlers (parameterised over `__proto__`, `constructor`, `prototype`) asserting:
1. the request is rejected with a `500` and the expected error body, and
2. `Object.prototype` is **not** polluted (a fresh object still has no `status`/`value`/`reputation`).

Verified the tests fail against the pre-fix code (they returned `200` and polluted the prototype) and pass with the fix.

Full suite: **557 passed** (34 suites, +12 new). `tsc --noEmit` and `eslint --max-warnings=0` both clean.

## Scope note

This is a targeted robustness fix, reachable regardless of the (deliberately) open control API surface. It came out of a broader multi-angle review; the larger items — the MongoDB per-request client lifecycle, the end-of-game 100ms polling loop, and the silent-lost-write conflict handling — are tracked separately in #782, #783, and the refactor issues #784/#785/#787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014huL94D5w7AgXvzbRY2fy9

---
_Generated by [Claude Code](https://claude.ai/code/session_014huL94D5w7AgXvzbRY2fy9)_