### PR TITLE
Fix game-ending polling storm at the turn limit (#782)

### DIFF
--- a/__test__/components/GameWrapper.test.tsx
+++ b/__test__/components/GameWrapper.test.tsx
@@ -7,8 +7,8 @@ import {
     jest,
     test,
 } from "@jest/globals";
-import { render } from "@testing-library/react";
-import { Game, SetupInformation } from "@fc/types/types";
+import { act, render } from "@testing-library/react";
+import { ApiResponse, Game, SetupInformation } from "@fc/types/types";
 import {
     makeActiveGame,
     makeInactiveGame,
@@ -19,9 +19,11 @@ import {
 // the poll interval first and the 1s local countdown second, so
 // mockIntervalDelays[0] is the poll cadence this test is about.
 const mockIntervalDelays: (number | null)[] = [];
+const mockIntervalCallbacks: (() => void)[] = [];
 jest.mock("@fc/lib/useInterval", () => ({
     __esModule: true,
-    default: (_callback: () => void, delay: number | null) => {
+    default: (callback: () => void, delay: number | null) => {
+        mockIntervalCallbacks.push(callback);
         mockIntervalDelays.push(delay);
     },
 }));
@@ -66,9 +68,16 @@ function pollDelay(): number {
     return delay as number;
 }
 
+// GameWrapper registers exactly two intervals per render (poll, then the 1s
+// countdown), so the poll delay from each render is at the even indices.
+function pollDelays(): (number | null)[] {
+    return mockIntervalDelays.filter((_, index) => index % 2 === 0);
+}
+
 describe("GameWrapper poll interval", () => {
     beforeEach(() => {
         mockIntervalDelays.length = 0;
+        mockIntervalCallbacks.length = 0;
         // Fixed jitter factor -> deterministic delays: the multiplier is
         // 1 + 0.5 * 0.25 = 1.125.
         jest.spyOn(Math, "random").mockReturnValue(0.5);
@@ -129,5 +138,48 @@ describe("GameWrapper poll interval", () => {
 
         expect(pollDelay()).toBe(5000);
         expect(pollDelay()).toBeGreaterThanOrEqual(1000);
+    });
+
+    test("re-derives the cadence when the game finishes mid-session", async () => {
+        // finished is a plain derived value, not memoised, so it must react to
+        // apiResponse changing after mount. This game has a turn limit but
+        // starts mid-game (phase 1), so it is not finished at mount.
+        const game = makeActiveGame({
+            setupInformation: finishedSetup,
+            turnInformation: {
+                turnNumber: 1,
+                currentPhase: 1,
+                phaseEnd: new Date(2023, 1, 2, 3, 5, 10, 0).toString(),
+            },
+        });
+
+        // When the poll fires, the server reports the game has hit its limit.
+        const finishedBody: ApiResponse = {
+            turnNumber: 1,
+            phase: finishedSetup.phases.length,
+            breakingNews: [],
+            active: true,
+            phaseEnd: 0,
+            components: [],
+        };
+        (global as unknown as { fetch: unknown }).fetch = jest.fn(() =>
+            Promise.resolve({ json: () => Promise.resolve(finishedBody) }),
+        );
+
+        render(<GameWrapper game={game} mode="Player" />);
+
+        // Mount: not finished yet -> steady active cadence.
+        expect(pollDelays().at(-1)).toBe(5625);
+
+        // Drive one poll cycle; the finished response flows into state and the
+        // component re-renders.
+        await act(async () => {
+            mockIntervalCallbacks[0]();
+        });
+
+        // The re-render re-derives finished from the new apiResponse and backs
+        // the poll interval off to the slow cadence - proving it is not frozen
+        // at its mount value.
+        expect(pollDelays().at(-1)).toBe(33750);
     });
 });

--- a/__test__/components/GameWrapper.test.tsx
+++ b/__test__/components/GameWrapper.test.tsx
@@ -1,0 +1,133 @@
+import {
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    jest,
+    test,
+} from "@jest/globals";
+import { render } from "@testing-library/react";
+import { Game, SetupInformation } from "@fc/types/types";
+import {
+    makeActiveGame,
+    makeInactiveGame,
+    setupInformation,
+} from "../fixtures/game";
+
+// Capture the delay handed to every useInterval call. GameWrapper registers
+// the poll interval first and the 1s local countdown second, so
+// mockIntervalDelays[0] is the poll cadence this test is about.
+const mockIntervalDelays: (number | null)[] = [];
+jest.mock("@fc/lib/useInterval", () => ({
+    __esModule: true,
+    default: (_callback: () => void, delay: number | null) => {
+        mockIntervalDelays.push(delay);
+    },
+}));
+
+// The themes render a large component tree that's irrelevant here (and pulls
+// in browser APIs jsdom can't provide); we only care about the poll interval.
+jest.mock("@fc/components/theme/first-contact/FirstContactTheme", () => ({
+    __esModule: true,
+    FirstContactTheme: () => null,
+}));
+jest.mock("@fc/components/theme/aftermath/AftermathTheme", () => ({
+    __esModule: true,
+    AftermathTheme: () => null,
+}));
+
+// The module under test is imported dynamically after the mocks above are
+// registered - the repo's established pattern (see __test__/app/game/api.test.ts).
+type GameWrapperModule = typeof import("../../src/app/game/[id]/GameWrapper");
+let GameWrapper: GameWrapperModule["default"];
+
+beforeAll(async () => {
+    ({ default: GameWrapper } =
+        await import("../../src/app/game/[id]/GameWrapper"));
+});
+
+// The default fixture's phaseEnd is in the past, so toApiResponse yields
+// phaseEnd === 0 - exactly the condition that used to collapse the poll
+// interval to 100ms. maxTurns:1 + the final phase makes atTurnLimit true.
+const finishedSetup: SetupInformation = { ...setupInformation, maxTurns: 1 };
+const finishedGame: Game = makeActiveGame({
+    setupInformation: finishedSetup,
+    turnInformation: {
+        turnNumber: 1,
+        currentPhase: finishedSetup.phases.length,
+        phaseEnd: new Date(2023, 1, 2, 3, 5, 10, 0).toString(),
+    },
+});
+
+function pollDelay(): number {
+    const delay = mockIntervalDelays[0];
+    expect(typeof delay).toBe("number");
+    return delay as number;
+}
+
+describe("GameWrapper poll interval", () => {
+    beforeEach(() => {
+        mockIntervalDelays.length = 0;
+        // Fixed jitter factor -> deterministic delays: the multiplier is
+        // 1 + 0.5 * 0.25 = 1.125.
+        jest.spyOn(Math, "random").mockReturnValue(0.5);
+        // jsdom doesn't implement media playback; GameWrapper constructs an
+        // Audio element in an effect, so provide a harmless stub.
+        (window as unknown as { Audio: unknown }).Audio = class {
+            play() {
+                return Promise.resolve();
+            }
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("polls at the steady active cadence for a running game", () => {
+        render(<GameWrapper game={makeActiveGame()} mode="Player" />);
+
+        // 5000 * 1.125
+        expect(pollDelay()).toBe(5625);
+    });
+
+    test("does not fast-poll at a phase boundary (phaseEnd === 0)", () => {
+        // The active fixture's phaseEnd is already in the past, so the initial
+        // apiResponse has phaseEnd === 0 - the old code polled every 100ms here.
+        render(<GameWrapper game={makeActiveGame()} mode="Player" />);
+
+        expect(pollDelay()).toBeGreaterThanOrEqual(1000);
+        expect(pollDelay()).not.toBe(100);
+    });
+
+    test("backs off to the slow cadence once the game has finished", () => {
+        render(<GameWrapper game={finishedGame} mode="Player" />);
+
+        // 30000 * 1.125
+        expect(pollDelay()).toBe(33750);
+    });
+
+    test("never collapses to the 100ms fast-poll for a finished game", () => {
+        render(<GameWrapper game={finishedGame} mode="Player" />);
+
+        expect(pollDelay()).toBeGreaterThanOrEqual(30000);
+        expect(pollDelay()).not.toBe(100);
+    });
+
+    test("backs off to the slow cadence while paused", () => {
+        render(<GameWrapper game={makeInactiveGame()} mode="Player" />);
+
+        expect(pollDelay()).toBe(33750);
+    });
+
+    test("floors the interval at 1s regardless of jitter", () => {
+        // Smallest possible jitter factor -> no inflation, bare base delay.
+        jest.spyOn(Math, "random").mockReturnValue(0);
+
+        render(<GameWrapper game={makeActiveGame()} mode="Player" />);
+
+        expect(pollDelay()).toBe(5000);
+        expect(pollDelay()).toBeGreaterThanOrEqual(1000);
+    });
+});

--- a/src/app/game/[id]/GameWrapper.tsx
+++ b/src/app/game/[id]/GameWrapper.tsx
@@ -2,7 +2,7 @@
 
 import { ApiResponse, Game } from "@fc/types/types";
 import React, { useEffect, useState } from "react";
-import { toApiResponse } from "@fc/server/turn";
+import { atTurnLimit, toApiResponse } from "@fc/server/turn";
 import useInterval from "@fc/lib/useInterval";
 import { ApiResponseDecode } from "@fc/types/io-ts-def";
 import ControlTools from "@fc/components/ControlTools";
@@ -36,40 +36,66 @@ export default function GameWrapper(props: GameWrapperProps) {
     useEffect(() => setAudio(new Audio("/turn-change.mp3")), []);
     const [fetching, setFetching] = useState<boolean>(false);
 
-    const delay = Math.min(apiResponse.phaseEnd * 1000, 5000);
-    useInterval(
-        () => {
-            if (fetching) {
-                return;
-            }
-
-            setFetching(true);
-
-            fetch(`/game/${game._id}/api`, {
-                cache: "no-cache",
-                headers: { accept: "application/json" },
-            })
-                .then((response) => response.json())
-                .then((body) => {
-                    if (ApiResponseDecode.is(body)) {
-                        setAPIResponse(body);
-
-                        if (
-                            triggersAudio.some(
-                                (val) => body[val] != apiResponse[val],
-                            )
-                        ) {
-                            audio?.play().catch((e) => console.log(e));
-                        }
-                    } else {
-                        throw new Error("Body did not match API");
-                    }
-                })
-                .catch((error) => console.error(error))
-                .finally(() => setFetching(false));
-        },
-        delay == 0 ? 100 : delay,
+    // A game that has reached its turn limit never advances again, so its
+    // phaseEnd stays at 0. We must not derive the poll interval from that (see
+    // below) or every device on the "GAME COMPLETE" screen would poll forever.
+    const finished = atTurnLimit(
+        apiResponse.turnNumber,
+        apiResponse.phase,
+        game.setupInformation,
     );
+
+    // A stable per-device jitter factor so devices don't poll in lockstep and
+    // stampede the API together (notably at phase boundaries and after the
+    // game ends). Kept in state so it doesn't change on every render and reset
+    // the interval.
+    const [jitterFactor] = useState(() => Math.random());
+
+    // The poll cadence is intentionally decoupled from the live countdown.
+    // Previously the delay was `Math.min(phaseEnd * 1000, 5000)`, which meant:
+    //   - phaseEnd === 0 (finished game, or transiently at every phase
+    //     boundary) collapsed the interval to 100ms — ~10 req/s per device
+    //     for the rest of the event.
+    //   - the delay changed every second in the final 5s as the local
+    //     countdown ticked, resetting useInterval before it could fire, so
+    //     clients got no sync in the last 5s and then all stampeded at 0.
+    // Instead: poll at a steady rate while active, back off once the game is
+    // finished or paused, floor at 1s, and spread devices out with jitter.
+    const basePollDelay = finished || !apiResponse.active ? 30000 : 5000;
+    const delay = Math.max(
+        1000,
+        Math.round(basePollDelay * (1 + jitterFactor * 0.25)),
+    );
+    useInterval(() => {
+        if (fetching) {
+            return;
+        }
+
+        setFetching(true);
+
+        fetch(`/game/${game._id}/api`, {
+            cache: "no-cache",
+            headers: { accept: "application/json" },
+        })
+            .then((response) => response.json())
+            .then((body) => {
+                if (ApiResponseDecode.is(body)) {
+                    setAPIResponse(body);
+
+                    if (
+                        triggersAudio.some(
+                            (val) => body[val] != apiResponse[val],
+                        )
+                    ) {
+                        audio?.play().catch((e) => console.log(e));
+                    }
+                } else {
+                    throw new Error("Body did not match API");
+                }
+            })
+            .catch((error) => console.error(error))
+            .finally(() => setFetching(false));
+    }, delay);
 
     useInterval(() => {
         if (!apiResponse.active) {


### PR DESCRIPTION
Fixes #782.

## Problem

When a game reaches its turn limit it never transitions to a terminal state. The server correctly refuses to advance past the limit (`hasFinished()` is `false` there), so `phaseEnd` stays `0` and `GameWrapper` collapses its poll interval to **100ms (~10 req/s) per device for the rest of the event** — a self-inflicted DDoS on the API from every screen showing "GAME COMPLETE".

Two related symptoms from the same root cause:
- The 100ms collapse also happened **transiently at every phase boundary** (all countdowns hit `0` together → synchronised burst).
- Because `delay` was derived from `phaseEnd` and the local countdown decremented it every second, `useInterval`'s effect reset before it could fire in the final 5s → **no server sync in the last 5s, then a synchronised stampede at `0`**.

## Fix

The change is entirely client-side in `GameWrapper.tsx` — the server behaviour (not advancing past the limit) is correct; the bug was deriving the poll cadence from `phaseEnd`.

- **Derive a `finished` flag** from `atTurnLimit(turnNumber, phase, setupInformation)` so the client can tell a genuinely finished game apart from a momentary phase boundary. No server type or DB migration needed — the client already has both the API response and `setupInformation`.
- **Decouple the poll cadence from the live countdown:** poll at a steady 5s while active, back off to 30s once the game is finished or paused, and floor the interval at 1s.
- **Add a stable per-device jitter factor** so devices don't poll in lockstep and stampede the API at boundaries.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` — clean
- `npx jest` — 545/545 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015EAMakDeexHjNkVPE6Krfo)_