### PR TITLE
fix: conditional game update silently no-ops on conflict (409 + retry)

### DIFF
--- a/__test__/app/game/control/conflict.test.ts
+++ b/__test__/app/game/control/conflict.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @jest-environment node
+ *
+ * Tests the shared CAS-conflict handling (retry once, then 409) that both the
+ * component route factory and the pause/play control route go through. See
+ * #783.
+ */
+import {
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    jest,
+    test,
+} from "@jest/globals";
+import type { Mock } from "jest-mock";
+import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
+import { makeActiveGame } from "../../../fixtures/game";
+import { makeProps, makeRequest } from "../../../fixtures/routes";
+import GameRepository, { UPDATE_CONFLICT } from "@fc/server/repository/game";
+
+jest.mock("@fc/server/repository/game", () => ({
+    __esModule: true,
+    getGameRepo: jest.fn(),
+    UPDATE_CONFLICT: "conflict",
+}));
+
+type Handler = (
+    request: ReturnType<typeof makeRequest>,
+    props: ReturnType<typeof makeProps>,
+) => Promise<Response>;
+
+let defconPost: Handler;
+let controlPost: Handler;
+let getGameRepo: Mock<() => ReturnType<typeof MakeRight<GameRepository>>>;
+
+beforeAll(async () => {
+    ({ getGameRepo } = (await import("@fc/server/repository/game")) as never);
+    ({ POST: defconPost } =
+        (await import("../../../../src/app/game/[id]/control/api/defcon/route")) as {
+            POST: Handler;
+        });
+    ({ POST: controlPost } =
+        (await import("../../../../src/app/game/[id]/control/api/route")) as {
+            POST: Handler;
+        });
+});
+
+const mockedDate = new Date(2023, 1, 2, 3, 4, 5, 0);
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(mockedDate);
+    getGameRepo.mockReset();
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+function makeRepo(
+    runControlAction: GameRepository["runControlAction"],
+): GameRepository {
+    const game = makeActiveGame();
+    return {
+        get: jest.fn<GameRepository["get"]>(async () => MakeRight(game)),
+        insert: jest.fn<GameRepository["insert"]>(async () =>
+            MakeRight<true>(true),
+        ),
+        nextTurn: jest.fn<GameRepository["nextTurn"]>(async (current) =>
+            MakeRight(current),
+        ),
+        runControlAction: jest.fn(runControlAction),
+        setBreakingNews: jest.fn<GameRepository["setBreakingNews"]>(
+            async (current) => MakeRight(current),
+        ),
+    };
+}
+
+describe("CAS conflict handling", () => {
+    describe.each([
+        {
+            name: "control route (pause)",
+            post: () => controlPost,
+            body: { action: "pause" },
+        },
+        {
+            name: "component route (defcon)",
+            post: () => defconPost,
+            body: { stateName: "China", newStatus: 1 },
+        },
+    ])("$name", ({ post, body }) => {
+        test("retries once and succeeds when the first update conflicts", async () => {
+            let calls = 0;
+            const runControlAction = jest.fn(async () => {
+                calls += 1;
+                return calls === 1
+                    ? MakeLeft(UPDATE_CONFLICT)
+                    : MakeRight(makeActiveGame());
+            }) as unknown as GameRepository["runControlAction"];
+
+            const repo = makeRepo(runControlAction);
+            getGameRepo.mockReturnValue(MakeRight(repo));
+
+            const response = await post()(makeRequest(body), makeProps());
+
+            expect(response.status).toBe(200);
+            expect(repo.runControlAction).toHaveBeenCalledTimes(2);
+            // Initial fetch + one re-fetch for the retry.
+            expect(repo.get).toHaveBeenCalledTimes(2);
+        });
+
+        test("returns 409 after a persistent conflict and only retries once", async () => {
+            const repo = makeRepo(async () => MakeLeft(UPDATE_CONFLICT));
+            getGameRepo.mockReturnValue(MakeRight(repo));
+
+            const response = await post()(makeRequest(body), makeProps());
+
+            expect(response.status).toBe(409);
+            expect(await response.json()).toEqual({ error: "conflict" });
+            expect(repo.runControlAction).toHaveBeenCalledTimes(2);
+        });
+
+        test("does not retry for a non-conflict error", async () => {
+            const repo = makeRepo(async () => MakeLeft("some other failure"));
+            getGameRepo.mockReturnValue(MakeRight(repo));
+
+            const response = await post()(makeRequest(body), makeProps());
+
+            expect(response.status).toBe(500);
+            expect(await response.json()).toEqual({
+                error: "some other failure",
+            });
+            expect(repo.runControlAction).toHaveBeenCalledTimes(1);
+        });
+
+        test("returns 404 when the game vanishes before the retry", async () => {
+            const repo = makeRepo(async () => MakeLeft(UPDATE_CONFLICT));
+            // First get succeeds, the retry re-fetch finds nothing.
+            (repo.get as Mock<GameRepository["get"]>)
+                .mockResolvedValueOnce(MakeRight(makeActiveGame()))
+                .mockResolvedValueOnce(MakeLeft(false));
+            getGameRepo.mockReturnValue(MakeRight(repo));
+
+            const response = await post()(makeRequest(body), makeProps());
+
+            expect(response.status).toBe(404);
+            // The action never ran a second time because the re-fetch failed.
+            expect(repo.runControlAction).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/__test__/app/game/control/conflict.test.ts
+++ b/__test__/app/game/control/conflict.test.ts
@@ -73,6 +73,9 @@ function makeRepo(
     const game = makeActiveGame();
     return {
         get: jest.fn<GameRepository["get"]>(async () => MakeRight(game)),
+        list: jest.fn<GameRepository["list"]>(async () =>
+            MakeRight({ games: [game], total: 1, page: 1 }),
+        ),
         insert: jest.fn<GameRepository["insert"]>(async () =>
             MakeRight<true>(true),
         ),
@@ -220,6 +223,9 @@ function makeCasRepo(): { repo: GameRepository; getStore: () => Game } {
 
     const repo: GameRepository = {
         get,
+        list: jest.fn<GameRepository["list"]>(async () =>
+            MakeRight({ games: [store], total: 1, page: 1 }),
+        ),
         insert: jest.fn<GameRepository["insert"]>(async () =>
             MakeRight<true>(true),
         ),

--- a/__test__/app/game/control/conflict.test.ts
+++ b/__test__/app/game/control/conflict.test.ts
@@ -23,7 +23,13 @@ import GameRepository, { UPDATE_CONFLICT } from "@fc/server/repository/game";
 jest.mock("@fc/server/repository/game", () => ({
     __esModule: true,
     getGameRepo: jest.fn(),
-    UPDATE_CONFLICT: "conflict",
+    // Use the real sentinel symbol so the route's conflict dispatch is exercised
+    // exactly as in production, not against a stand-in string.
+    UPDATE_CONFLICT: (
+        jest.requireActual("@fc/server/repository/game") as {
+            UPDATE_CONFLICT: symbol;
+        }
+    ).UPDATE_CONFLICT,
 }));
 
 type Handler = (

--- a/__test__/app/game/control/conflict.test.ts
+++ b/__test__/app/game/control/conflict.test.ts
@@ -15,10 +15,12 @@ import {
     test,
 } from "@jest/globals";
 import type { Mock } from "jest-mock";
+import { isLeft } from "fp-ts/Either";
 import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
 import { makeActiveGame } from "../../../fixtures/game";
 import { makeProps, makeRequest } from "../../../fixtures/routes";
 import GameRepository, { UPDATE_CONFLICT } from "@fc/server/repository/game";
+import { Game } from "@fc/types/types";
 
 jest.mock("@fc/server/repository/game", () => ({
     __esModule: true,
@@ -155,5 +157,115 @@ describe("CAS conflict handling", () => {
             // The action never ran a second time because the re-fetch failed.
             expect(repo.runControlAction).toHaveBeenCalledTimes(1);
         });
+    });
+});
+
+/**
+ * A repository whose runControlAction performs a real compare-and-set on
+ * turnInformation. A concurrent writer advances the game by one phase right
+ * after the first read, so the operator's action always conflicts on its first
+ * attempt. This lets us assert the resulting turn VALUE (single vs double
+ * advance), not just call counts.
+ */
+function makeCasRepo(): { repo: GameRepository; getStore: () => Game } {
+    // Start on phase 1.
+    let store = makeActiveGame({
+        turnInformation: {
+            turnNumber: 1,
+            currentPhase: 1,
+            phaseEnd: makeActiveGame().turnInformation.phaseEnd,
+        },
+    });
+    let concurrentAdvancesLeft = 1;
+
+    const get = jest.fn<GameRepository["get"]>(async () => {
+        const snapshot = store;
+
+        if (concurrentAdvancesLeft > 0) {
+            concurrentAdvancesLeft -= 1;
+            // Simulate another writer advancing the turn immediately after this
+            // read, so the caller's snapshot is now stale.
+            store = {
+                ...store,
+                turnInformation: {
+                    ...store.turnInformation,
+                    currentPhase: store.turnInformation.currentPhase + 1,
+                },
+            };
+        }
+
+        return MakeRight(snapshot);
+    });
+
+    const runControlAction = jest.fn<GameRepository["runControlAction"]>(
+        async (currentGame, action) => {
+            // Compare-and-set on turnInformation, mirroring the Mongo filter.
+            if (
+                JSON.stringify(store.turnInformation) !==
+                JSON.stringify(currentGame.turnInformation)
+            ) {
+                return MakeLeft(UPDATE_CONFLICT);
+            }
+
+            const result = action(currentGame);
+
+            if (isLeft(result)) {
+                return result;
+            }
+
+            store = { ...store, ...result.right } as Game;
+            return MakeRight(store);
+        },
+    );
+
+    const repo: GameRepository = {
+        get,
+        insert: jest.fn<GameRepository["insert"]>(async () =>
+            MakeRight<true>(true),
+        ),
+        nextTurn: jest.fn<GameRepository["nextTurn"]>(async (current) =>
+            MakeRight(current),
+        ),
+        runControlAction,
+        setBreakingNews: jest.fn<GameRepository["setBreakingNews"]>(
+            async (current) => MakeRight(current),
+        ),
+    };
+
+    return { repo, getStore: () => store };
+}
+
+describe("retry safety by action type", () => {
+    test("a relative turn action returns 409 without retrying or double-advancing", async () => {
+        const { repo, getStore } = makeCasRepo();
+        getGameRepo.mockReturnValue(MakeRight(repo));
+
+        const response = await controlPost(
+            makeRequest({ action: "forward-phase" }),
+            makeProps(),
+        );
+
+        expect(response.status).toBe(409);
+        expect(await response.json()).toEqual({ error: "conflict" });
+        // No retry: the action was attempted exactly once.
+        expect(repo.runControlAction).toHaveBeenCalledTimes(1);
+        // The game advanced exactly once (to phase 2 by the concurrent writer),
+        // NOT twice - the operator's forward-phase was not re-applied.
+        expect(getStore().turnInformation.currentPhase).toBe(2);
+        expect(getStore().turnInformation.turnNumber).toBe(1);
+    });
+
+    test("an idempotent action still retries once and succeeds", async () => {
+        const { repo } = makeCasRepo();
+        getGameRepo.mockReturnValue(MakeRight(repo));
+
+        const response = await controlPost(
+            makeRequest({ action: "pause" }),
+            makeProps(),
+        );
+
+        expect(response.status).toBe(200);
+        // First attempt conflicts, the re-fetched attempt succeeds.
+        expect(repo.runControlAction).toHaveBeenCalledTimes(2);
     });
 });

--- a/__test__/server/repository/game/mongo.test.ts
+++ b/__test__/server/repository/game/mongo.test.ts
@@ -13,6 +13,7 @@ import {
 import { isLeft, isRight } from "fp-ts/Either";
 import { MongoClient } from "mongodb";
 import { MongoRepository } from "@fc/server/repository/game/mongo";
+import { UPDATE_CONFLICT } from "@fc/server/repository/game";
 import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
 import { Game } from "@fc/types/types";
 import { makeActiveGame } from "../../../fixtures/game";
@@ -48,8 +49,11 @@ function makeFakeMongo() {
             async () => ({}),
         ),
         updateOne: jest.fn<
-            (filter: unknown, update: unknown) => Promise<object>
-        >(async () => ({})),
+            (
+                filter: unknown,
+                update: unknown,
+            ) => Promise<{ matchedCount: number }>
+        >(async () => ({ matchedCount: 1 })),
     };
     const db = {
         collection: jest.fn<(name: string) => typeof collection>(
@@ -354,6 +358,16 @@ describe("nextTurn", () => {
 
         expect(result).toEqual(MakeLeft("Failed to get game?"));
     });
+
+    test("returns a conflict when the CAS update matches no documents", async () => {
+        const { collection, repository } = makeFakeMongo();
+
+        collection.updateOne.mockResolvedValue({ matchedCount: 0 });
+
+        const result = await repository.nextTurn(makeActiveGame());
+
+        expect(result).toEqual(MakeLeft(UPDATE_CONFLICT));
+    });
 });
 
 describe("runControlAction", () => {
@@ -411,6 +425,18 @@ describe("runControlAction", () => {
         );
 
         expect(result).toEqual(MakeLeft("Failed to get game?"));
+    });
+
+    test("returns a conflict when the CAS update matches no documents", async () => {
+        const { collection, repository } = makeFakeMongo();
+
+        collection.updateOne.mockResolvedValue({ matchedCount: 0 });
+
+        const result = await repository.runControlAction(makeActiveGame(), () =>
+            MakeRight({ active: true }),
+        );
+
+        expect(result).toEqual(MakeLeft(UPDATE_CONFLICT));
     });
 });
 

--- a/__test__/server/repository/game/mongo.test.ts
+++ b/__test__/server/repository/game/mongo.test.ts
@@ -359,14 +359,43 @@ describe("nextTurn", () => {
         expect(result).toEqual(MakeLeft("Failed to get game?"));
     });
 
-    test("returns a conflict when the CAS update matches no documents", async () => {
-        const { collection, repository } = makeFakeMongo();
+    test("returns the fresh advanced state when the CAS update conflicts", async () => {
+        const { cursor, collection, repository } = makeFakeMongo();
+
+        // The CAS matched nothing: another writer already advanced the turn.
+        collection.updateOne.mockResolvedValue({ matchedCount: 0 });
+
+        // The re-fetch returns the already-advanced (phase 2) game.
+        const freshGame = makeActiveGame({
+            turnInformation: {
+                turnNumber: 1,
+                currentPhase: 2,
+                phaseEnd: new Date(2023, 1, 2, 3, 6, 5, 0).toString(),
+            },
+        });
+        cursor.next.mockResolvedValue(freshGame);
+
+        // The stale input is still on phase 1.
+        const staleGame = makeActiveGame();
+        const result = await repository.nextTurn(staleGame);
+
+        // A lost auto-advance is success from the poller's view: it gets the
+        // fresh advanced state, not the stale pre-advance one.
+        expect(result).toEqual(MakeRight(freshGame));
+        if (isRight(result)) {
+            expect(result.right.turnInformation.currentPhase).toBe(2);
+        }
+    });
+
+    test("returns a left when the game cannot be re-fetched after a conflict", async () => {
+        const { cursor, collection, repository } = makeFakeMongo();
 
         collection.updateOne.mockResolvedValue({ matchedCount: 0 });
+        cursor.next.mockResolvedValue(null);
 
         const result = await repository.nextTurn(makeActiveGame());
 
-        expect(result).toEqual(MakeLeft(UPDATE_CONFLICT));
+        expect(result).toEqual(MakeLeft("Failed to get game?"));
     });
 });
 

--- a/src/app/game/[id]/control/api/route.ts
+++ b/src/app/game/[id]/control/api/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ApiResponse } from "@fc/types/types";
-import { isLeft } from "fp-ts/Either";
-import { getGameRepo } from "@fc/server/repository/game";
 import { ControlAPIDecode } from "@fc/types/io-ts-def";
-import { CONTROL_ACTIONS, toApiResponse } from "@fc/server/turn";
+import { CONTROL_ACTIONS } from "@fc/server/turn";
+import { runControlActionRoute } from "@fc/server/components";
 
 export async function POST(
     request: NextRequest,
@@ -21,26 +20,5 @@ export async function POST(
         );
     }
 
-    const gameRepo = getGameRepo();
-
-    if (isLeft(gameRepo)) {
-        return NextResponse.json({ error: gameRepo.left }, { status: 500 });
-    }
-
-    const game = await gameRepo.right.get(id);
-
-    if (isLeft(game)) {
-        return NextResponse.json({ error: "Game not found" }, { status: 404 });
-    }
-
-    const newGame = await gameRepo.right.runControlAction(
-        game.right,
-        CONTROL_ACTIONS[body.action],
-    );
-
-    if (isLeft(newGame)) {
-        return NextResponse.json({ error: newGame.left }, { status: 500 });
-    }
-
-    return NextResponse.json(toApiResponse(newGame.right));
+    return runControlActionRoute(id, CONTROL_ACTIONS[body.action]);
 }

--- a/src/app/game/[id]/control/api/route.ts
+++ b/src/app/game/[id]/control/api/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ApiResponse } from "@fc/types/types";
 import { ControlAPIDecode } from "@fc/types/io-ts-def";
-import { CONTROL_ACTIONS } from "@fc/server/turn";
+import { CONTROL_ACTIONS, isRetrySafeAction } from "@fc/server/turn";
 import { runControlActionRoute } from "@fc/server/control-route";
 
 export async function POST(
@@ -20,5 +20,12 @@ export async function POST(
         );
     }
 
-    return runControlActionRoute(id, CONTROL_ACTIONS[body.action]);
+    // Relative turn-navigation actions must not be auto-retried on a CAS
+    // conflict (re-applying would double-advance the game); idempotent actions
+    // such as pause/play are safe to retry. See #783.
+    return runControlActionRoute(
+        id,
+        CONTROL_ACTIONS[body.action],
+        isRetrySafeAction(body.action),
+    );
 }

--- a/src/app/game/[id]/control/api/route.ts
+++ b/src/app/game/[id]/control/api/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { ApiResponse } from "@fc/types/types";
 import { ControlAPIDecode } from "@fc/types/io-ts-def";
 import { CONTROL_ACTIONS } from "@fc/server/turn";
-import { runControlActionRoute } from "@fc/server/components";
+import { runControlActionRoute } from "@fc/server/control-route";
 
 export async function POST(
     request: NextRequest,

--- a/src/server/components.ts
+++ b/src/server/components.ts
@@ -1,15 +1,11 @@
-import {
-    ApiResponse,
-    Component,
-    ComponentType,
-    ControlAction,
-    Game,
-} from "@fc/types/types";
+import { Component, ComponentType, Game } from "@fc/types/types";
 import { Either, isLeft } from "fp-ts/Either";
 import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
 import { NextRequest, NextResponse } from "next/server";
-import { getGameRepo, UPDATE_CONFLICT } from "@fc/server/repository/game";
-import { toApiResponse } from "@fc/server/turn";
+import {
+    ControlRouteResponse,
+    runControlActionRoute,
+} from "@fc/server/control-route";
 
 /**
  * The concrete component variant for a given componentType discriminant.
@@ -126,64 +122,10 @@ export function componentAction<T extends ComponentType, B>(
     };
 }
 
-type ControlRouteResponse = NextResponse<ApiResponse | { error: string }>;
-
 type ComponentRouteHandler = (
     request: NextRequest,
     props: { params: Promise<{ id: string }> },
 ) => Promise<ControlRouteResponse>;
-
-/**
- * Runs a control action for a game and maps the result to a response, shared by
- * the component routes and the pause/play control route.
- *
- * The repository update is a compare-and-set on turnInformation, which can lose
- * to a concurrent writer (e.g. a lazy auto-advance triggered by a player's
- * poll). On such a conflict this re-fetches the game and re-applies the action
- * once; a persistent conflict surfaces as HTTP 409 rather than a silent success
- * with the other writer's state. See #783.
- */
-export async function runControlActionRoute(
-    id: string,
-    action: ControlAction,
-): Promise<ControlRouteResponse> {
-    const gameRepo = getGameRepo();
-
-    if (isLeft(gameRepo)) {
-        return NextResponse.json({ error: gameRepo.left }, { status: 500 });
-    }
-
-    const game = await gameRepo.right.get(id);
-
-    if (isLeft(game)) {
-        return NextResponse.json({ error: "Game not found" }, { status: 404 });
-    }
-
-    let result = await gameRepo.right.runControlAction(game.right, action);
-
-    if (isLeft(result) && result.left === UPDATE_CONFLICT) {
-        const fresh = await gameRepo.right.get(id);
-
-        if (isLeft(fresh)) {
-            return NextResponse.json(
-                { error: "Game not found" },
-                { status: 404 },
-            );
-        }
-
-        result = await gameRepo.right.runControlAction(fresh.right, action);
-    }
-
-    if (isLeft(result)) {
-        if (result.left === UPDATE_CONFLICT) {
-            return NextResponse.json({ error: "conflict" }, { status: 409 });
-        }
-
-        return NextResponse.json({ error: result.left }, { status: 500 });
-    }
-
-    return NextResponse.json(toApiResponse(result.right));
-}
 
 /**
  * Builds a control route handler for a component. Collapses the ~70-line

--- a/src/server/components.ts
+++ b/src/server/components.ts
@@ -1,8 +1,14 @@
-import { ApiResponse, Component, ComponentType, Game } from "@fc/types/types";
+import {
+    ApiResponse,
+    Component,
+    ComponentType,
+    ControlAction,
+    Game,
+} from "@fc/types/types";
 import { Either, isLeft } from "fp-ts/Either";
 import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
 import { NextRequest, NextResponse } from "next/server";
-import { getGameRepo } from "@fc/server/repository/game";
+import { getGameRepo, UPDATE_CONFLICT } from "@fc/server/repository/game";
 import { toApiResponse } from "@fc/server/turn";
 
 /**
@@ -120,10 +126,64 @@ export function componentAction<T extends ComponentType, B>(
     };
 }
 
+type ControlRouteResponse = NextResponse<ApiResponse | { error: string }>;
+
 type ComponentRouteHandler = (
     request: NextRequest,
     props: { params: Promise<{ id: string }> },
-) => Promise<NextResponse<ApiResponse | { error: string }>>;
+) => Promise<ControlRouteResponse>;
+
+/**
+ * Runs a control action for a game and maps the result to a response, shared by
+ * the component routes and the pause/play control route.
+ *
+ * The repository update is a compare-and-set on turnInformation, which can lose
+ * to a concurrent writer (e.g. a lazy auto-advance triggered by a player's
+ * poll). On such a conflict this re-fetches the game and re-applies the action
+ * once; a persistent conflict surfaces as HTTP 409 rather than a silent success
+ * with the other writer's state. See #783.
+ */
+export async function runControlActionRoute(
+    id: string,
+    action: ControlAction,
+): Promise<ControlRouteResponse> {
+    const gameRepo = getGameRepo();
+
+    if (isLeft(gameRepo)) {
+        return NextResponse.json({ error: gameRepo.left }, { status: 500 });
+    }
+
+    const game = await gameRepo.right.get(id);
+
+    if (isLeft(game)) {
+        return NextResponse.json({ error: "Game not found" }, { status: 404 });
+    }
+
+    let result = await gameRepo.right.runControlAction(game.right, action);
+
+    if (isLeft(result) && result.left === UPDATE_CONFLICT) {
+        const fresh = await gameRepo.right.get(id);
+
+        if (isLeft(fresh)) {
+            return NextResponse.json(
+                { error: "Game not found" },
+                { status: 404 },
+            );
+        }
+
+        result = await gameRepo.right.runControlAction(fresh.right, action);
+    }
+
+    if (isLeft(result)) {
+        if (result.left === UPDATE_CONFLICT) {
+            return NextResponse.json({ error: "conflict" }, { status: 409 });
+        }
+
+        return NextResponse.json({ error: result.left }, { status: 500 });
+    }
+
+    return NextResponse.json(toApiResponse(result.right));
+}
 
 /**
  * Builds a control route handler for a component. Collapses the ~70-line
@@ -161,22 +221,7 @@ export function makeComponentRoute<T extends ComponentType>(
             );
         }
 
-        const gameRepo = getGameRepo();
-
-        if (isLeft(gameRepo)) {
-            return NextResponse.json({ error: gameRepo.left }, { status: 500 });
-        }
-
-        const game = await gameRepo.right.get(id);
-
-        if (isLeft(game)) {
-            return NextResponse.json(
-                { error: "Game not found" },
-                { status: 404 },
-            );
-        }
-
-        const newGame = await gameRepo.right.runControlAction(game.right, (g) =>
+        return runControlActionRoute(id, (g) =>
             updateComponent(
                 g,
                 componentType,
@@ -185,11 +230,5 @@ export function makeComponentRoute<T extends ComponentType>(
                 notFoundLabel,
             ),
         );
-
-        if (isLeft(newGame)) {
-            return NextResponse.json({ error: newGame.left }, { status: 500 });
-        }
-
-        return NextResponse.json(toApiResponse(newGame.right));
     };
 }

--- a/src/server/control-route.ts
+++ b/src/server/control-route.ts
@@ -1,0 +1,61 @@
+import { ApiResponse, ControlAction } from "@fc/types/types";
+import { isLeft } from "fp-ts/Either";
+import { NextResponse } from "next/server";
+import { getGameRepo, UPDATE_CONFLICT } from "@fc/server/repository/game";
+import { toApiResponse } from "@fc/server/turn";
+
+export type ControlRouteResponse = NextResponse<
+    ApiResponse | { error: string }
+>;
+
+/**
+ * Runs a control action for a game and maps the result to a response, shared by
+ * the component route factory and the pause/play control route.
+ *
+ * The repository update is a compare-and-set on turnInformation, which can lose
+ * to a concurrent writer (e.g. a lazy auto-advance triggered by a player's
+ * poll). On such a conflict this re-fetches the game and re-applies the action
+ * once; a persistent conflict surfaces as HTTP 409 rather than a silent success
+ * with the other writer's state. See #783.
+ */
+export async function runControlActionRoute(
+    id: string,
+    action: ControlAction,
+): Promise<ControlRouteResponse> {
+    const gameRepo = getGameRepo();
+
+    if (isLeft(gameRepo)) {
+        return NextResponse.json({ error: gameRepo.left }, { status: 500 });
+    }
+
+    const game = await gameRepo.right.get(id);
+
+    if (isLeft(game)) {
+        return NextResponse.json({ error: "Game not found" }, { status: 404 });
+    }
+
+    let result = await gameRepo.right.runControlAction(game.right, action);
+
+    if (isLeft(result) && result.left === UPDATE_CONFLICT) {
+        const fresh = await gameRepo.right.get(id);
+
+        if (isLeft(fresh)) {
+            return NextResponse.json(
+                { error: "Game not found" },
+                { status: 404 },
+            );
+        }
+
+        result = await gameRepo.right.runControlAction(fresh.right, action);
+    }
+
+    if (isLeft(result)) {
+        if (result.left === UPDATE_CONFLICT) {
+            return NextResponse.json({ error: "conflict" }, { status: 409 });
+        }
+
+        return NextResponse.json({ error: result.left }, { status: 500 });
+    }
+
+    return NextResponse.json(toApiResponse(result.right));
+}

--- a/src/server/control-route.ts
+++ b/src/server/control-route.ts
@@ -14,13 +14,23 @@ export type ControlRouteResponse = NextResponse<
  *
  * The repository update is a compare-and-set on turnInformation, which can lose
  * to a concurrent writer (e.g. a lazy auto-advance triggered by a player's
- * poll). On such a conflict this re-fetches the game and re-applies the action
- * once; a persistent conflict surfaces as HTTP 409 rather than a silent success
- * with the other writer's state. See #783.
+ * poll). How a conflict is handled depends on whether the action is safe to
+ * re-apply on fresh state:
+ *
+ *  - Idempotent actions (component edits, and pause/play which set absolute
+ *    state) are re-fetched and re-applied once; a persistent conflict is a 409.
+ *  - Non-idempotent actions (relative turn navigation such as forward-phase)
+ *    must NOT be retried: re-applying on already-advanced state would advance
+ *    the game a second time. They return 409 immediately so the operator can
+ *    re-decide against fresh state.
+ *
+ * Callers pass retryOnConflict accordingly (default true for the idempotent
+ * component-edit path). See #783.
  */
 export async function runControlActionRoute(
     id: string,
     action: ControlAction,
+    retryOnConflict: boolean = true,
 ): Promise<ControlRouteResponse> {
     const gameRepo = getGameRepo();
 
@@ -36,7 +46,7 @@ export async function runControlActionRoute(
 
     let result = await gameRepo.right.runControlAction(game.right, action);
 
-    if (isLeft(result) && result.left === UPDATE_CONFLICT) {
+    if (isLeft(result) && result.left === UPDATE_CONFLICT && retryOnConflict) {
         const fresh = await gameRepo.right.get(id);
 
         if (isLeft(fresh)) {

--- a/src/server/repository/game/index.ts
+++ b/src/server/repository/game/index.ts
@@ -15,6 +15,14 @@ export interface ListGamesResult {
     page: number;
 }
 
+/**
+ * Distinguishable error value returned by the game repository when a
+ * compare-and-set update matches zero documents - i.e. turnInformation changed
+ * between the read and the write. The route layer maps this to HTTP 409 and
+ * retries once. See #783.
+ */
+export const UPDATE_CONFLICT = "conflict";
+
 export default interface GameRepository {
     get: (id: string) => Promise<Either<false, Game>>;
     list: (opts: ListGamesOptions) => Promise<Either<string, ListGamesResult>>;

--- a/src/server/repository/game/index.ts
+++ b/src/server/repository/game/index.ts
@@ -18,10 +18,14 @@ export interface ListGamesResult {
 /**
  * Distinguishable error value returned by the game repository when a
  * compare-and-set update matches zero documents - i.e. turnInformation changed
- * between the read and the write. The route layer maps this to HTTP 409 and
- * retries once. See #783.
+ * between the read and the write.
+ *
+ * This is a unique symbol rather than a string so it can never collide with a
+ * human-readable error message that happens to read "conflict"; the two share
+ * the `Either` left channel. The route layer maps it to HTTP 409. See #783.
  */
-export const UPDATE_CONFLICT = "conflict";
+export const UPDATE_CONFLICT: unique symbol = Symbol("game-update-conflict");
+export type UpdateConflict = typeof UPDATE_CONFLICT;
 
 export default interface GameRepository {
     get: (id: string) => Promise<Either<false, Game>>;
@@ -31,7 +35,7 @@ export default interface GameRepository {
     runControlAction: (
         currentGame: Game,
         action: ControlAction,
-    ) => Promise<Either<string, Game>>;
+    ) => Promise<Either<string | UpdateConflict, Game>>;
     setBreakingNews: (
         currentGame: Game,
         breakingNews: string,

--- a/src/server/repository/game/mongo.ts
+++ b/src/server/repository/game/mongo.ts
@@ -1,4 +1,8 @@
-import GameRepository, { ListGamesOptions, ListGamesResult } from "./index";
+import GameRepository, {
+    ListGamesOptions,
+    ListGamesResult,
+    UPDATE_CONFLICT,
+} from "./index";
 import { Either, isLeft } from "fp-ts/Either";
 import { ControlAction, Game } from "@fc/types/types";
 import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
@@ -114,10 +118,18 @@ export class MongoRepository implements GameRepository {
 
             const { _id, turnInformation } = currentFields;
 
-            await gameCollection.updateOne(
+            const result = await gameCollection.updateOne(
                 { _id, turnInformation },
                 { $set: newFields },
             );
+
+            // The CAS filter on { _id, turnInformation } prevents double
+            // advances, but a 0-match means turnInformation changed between the
+            // read and this write. Surface that as a conflict rather than
+            // silently no-opping and returning success. See #783.
+            if (result.matchedCount === 0) {
+                return MakeLeft(UPDATE_CONFLICT);
+            }
 
             return MakeRight(true);
         } catch (e) {

--- a/src/server/repository/game/mongo.ts
+++ b/src/server/repository/game/mongo.ts
@@ -119,6 +119,13 @@ export class MongoRepository implements GameRepository {
 
             const { _id, turnInformation } = currentFields;
 
+            // The compare-and-set filter is keyed on turnInformation ONLY. It
+            // guards against concurrent turn advances, but NOT against two
+            // operators editing DIFFERENT components at the same time - those
+            // still last-write-wins, because neither touches turnInformation.
+            // Closing that gap needs a monotonic `version` field on the document
+            // (plus a data migration to backfill it), which is a deliberately
+            // deferred follow-up. See #783.
             const result = await gameCollection.updateOne(
                 { _id, turnInformation },
                 { $set: newFields },

--- a/src/server/repository/game/mongo.ts
+++ b/src/server/repository/game/mongo.ts
@@ -2,6 +2,7 @@ import GameRepository, {
     ListGamesOptions,
     ListGamesResult,
     UPDATE_CONFLICT,
+    UpdateConflict,
 } from "./index";
 import { Either, isLeft } from "fp-ts/Either";
 import { ControlAction, Game } from "@fc/types/types";
@@ -110,7 +111,7 @@ export class MongoRepository implements GameRepository {
     async #updateTurn(
         newFields: Partial<Game>,
         currentFields: Game,
-    ): Promise<Either<string, true>> {
+    ): Promise<Either<string | UpdateConflict, true>> {
         try {
             const database = (await this.mongo).db();
 
@@ -146,7 +147,17 @@ export class MongoRepository implements GameRepository {
         );
 
         if (isLeft(updateResult)) {
-            return updateResult;
+            // A lost auto-advance means another writer already advanced the turn
+            // (typically another player's poll). From the poller's point of view
+            // that is success, so return the fresh, already-advanced state
+            // instead of falling back to the stale pre-advance turn. See #783.
+            if (updateResult.left === UPDATE_CONFLICT) {
+                const fresh = await this.get(game._id);
+
+                return isRight(fresh) ? fresh : MakeLeft("Failed to get game?");
+            }
+
+            return MakeLeft(updateResult.left);
         }
 
         const result = await this.get(game._id);
@@ -157,7 +168,7 @@ export class MongoRepository implements GameRepository {
     async runControlAction(
         currentGame: Game,
         action: ControlAction,
-    ): Promise<Either<string, Game>> {
+    ): Promise<Either<string | UpdateConflict, Game>> {
         const tickedTurn = action(currentGame);
 
         if (isLeft(tickedTurn)) {

--- a/src/server/turn.ts
+++ b/src/server/turn.ts
@@ -385,6 +385,24 @@ export const CONTROL_ACTIONS: Record<ControlAPI["action"], ControlAction> = {
     },
 };
 
+/**
+ * The relative turn-navigation actions: each computes the new turn/phase as an
+ * offset from the CURRENT state. Re-applying one on already-advanced state would
+ * advance the game a second time, so on a CAS conflict the route must NOT retry
+ * them (it returns 409 and lets the operator re-decide). pause/play are absent
+ * because they set absolute state and are safe to re-apply on fresh state.
+ */
+export const RELATIVE_CONTROL_ACTIONS: ReadonlySet<ControlAPI["action"]> =
+    new Set(["forward-phase", "back-phase", "forward-turn", "back-turn"]);
+
+/**
+ * Whether a control action is safe to auto-retry once on a CAS conflict.
+ * Idempotent/absolute actions are; relative turn navigation is not.
+ */
+export function isRetrySafeAction(action: ControlAPI["action"]): boolean {
+    return !RELATIVE_CONTROL_ACTIONS.has(action);
+}
+
 export function generateNewTurnInformation(
     phase: Game["turnInformation"]["currentPhase"],
     turn: Game["turnInformation"]["turnNumber"],


### PR DESCRIPTION
Closes #783

> **Stacked on #791** (`claude/791-mongo-client-cache`, PR #798), which is itself stacked on #784 (PR #796). Merge #784 → #791 → this, in order. This PR's diff is against the #791 branch; once #791 merges the base retargets automatically.

## Problem

`#updateTurn` did a compare-and-set `updateOne({ _id, turnInformation }, { $set })` but ignored `matchedCount`. If `turnInformation` changed between the route's `get()` and the `updateOne()` (any player's `GET` can trigger a lazy auto-advance, or two operators act at once), the update matched **0 documents**, silently no-oped, and still returned `Right(true)`. The route then re-fetched and returned **HTTP 200 with the other writer's state** — the control action was silently lost with a success-shaped response.

## Fix

- **`#updateTurn`** returns a conflict when `matchedCount === 0`. The sentinel is a unique **`symbol`** (`UPDATE_CONFLICT`, exported from `src/server/repository/game/index.ts`) rather than a string, so it can never collide with a human-readable error message on the shared `Either` error channel.
- **Retry safety depends on the action.** The shared `runControlActionRoute` helper (extracted into `src/server/control-route.ts`) maps a conflict to **HTTP 409**, but only auto-retries when the action is safe to re-apply on fresh state:
  - **Idempotent** actions — component edits, and `pause`/`play` (which set absolute state) — re-`get` and re-apply **once**; a persistent conflict is a 409.
  - **Relative turn-navigation** actions (`forward-phase`/`back-phase`/`forward-turn`/`back-turn`) are **not** retried: re-applying on already-advanced state would double-advance the game. They return **409 immediately** so the operator re-decides against fresh state. Marked via `RELATIVE_CONTROL_ACTIONS`/`isRetrySafeAction` in `src/server/turn.ts`.
- **Player polls self-heal.** `nextTurn` no longer propagates the conflict; on a lost auto-advance it re-`get`s and returns the **fresh, already-advanced** state as a `Right`. A lost auto-advance means someone already advanced the turn, which is success from a poller's view — so pollers no longer briefly serve the stale pre-advance phase at each boundary.

## Concurrency scope (not a full guarantee)

The compare-and-set key is **`turnInformation` only**. It prevents concurrent/duplicate turn advances, but two operators editing **different components** at the same time still **last-write-wins**, because neither touches `turnInformation`. Closing that gap needs a monotonic `version` field on the document plus a data migration to backfill existing games — **intentionally deferred** as a tracked follow-up, since the migration is riskier than this scope warrants.

## Tests

- Repository: a conflicting `nextTurn` returns the **fresh advanced state** (asserting the turn/phase value), not the stale one; `runControlAction` still surfaces the conflict sentinel.
- Routes: an idempotent action retries once and succeeds (200); a persistent conflict returns 409 after **exactly one** retry; a non-conflict error is not retried (500); a game vanishing before the retry returns 404.
- Retry safety: a relative turn action on conflict returns **409 without retrying**, and the resulting turn **advanced exactly once** (value asserted, not just call count); an idempotent action still retries once and succeeds.

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm test` — passing

E2E: the conflict is a concurrency race that isn't deterministically reproducible from `e2e/`; it is covered by the unit/route tests above. Existing e2e is unaffected (needs Mongo + a running app; not run in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJrrE9HdR74taR2vvF5UHx