### PR TITLE
feat(admin): add paginated, searchable games list with share QR codes

### DIFF
--- a/__test__/fixtures/game.ts
+++ b/__test__/fixtures/game.ts
@@ -81,6 +81,9 @@ export function makeInactiveGame(
 export function makeFakeGameRepo(game: Game) {
     return {
         get: jest.fn<GameRepository["get"]>(async () => MakeRight(game)),
+        list: jest.fn<GameRepository["list"]>(async () =>
+            MakeRight({ games: [game], total: 1, page: 1 }),
+        ),
         insert: jest.fn<GameRepository["insert"]>(async () =>
             MakeRight<true>(true),
         ),

--- a/__test__/server/repository/game/mongo.test.ts
+++ b/__test__/server/repository/game/mongo.test.ts
@@ -17,12 +17,33 @@ import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
 import { Game } from "@fc/types/types";
 import { makeActiveGame } from "../../../fixtures/game";
 
+type FakeCursor = {
+    next: () => Promise<Game | null>;
+    sort: (spec: Record<string, 1 | -1>) => FakeCursor;
+    skip: (n: number) => FakeCursor;
+    limit: (n: number) => FakeCursor;
+    toArray: () => Promise<Game[]>;
+};
+
 function makeFakeMongo() {
+    // The list() cursor chain: sort/skip/limit return the cursor so they can be
+    // chained, and toArray resolves the results. The chain methods are wired to
+    // return `cursor` after construction to avoid referencing it before init.
     const cursor = {
         next: jest.fn<() => Promise<Game | null>>(async () => null),
+        sort: jest.fn<FakeCursor["sort"]>(),
+        skip: jest.fn<FakeCursor["skip"]>(),
+        limit: jest.fn<FakeCursor["limit"]>(),
+        toArray: jest.fn<() => Promise<Game[]>>(async () => []),
     };
+    cursor.sort.mockReturnValue(cursor);
+    cursor.skip.mockReturnValue(cursor);
+    cursor.limit.mockReturnValue(cursor);
     const collection = {
         find: jest.fn<(query: unknown) => typeof cursor>(() => cursor),
+        countDocuments: jest.fn<(query: unknown) => Promise<number>>(
+            async () => 0,
+        ),
         insertOne: jest.fn<(game: unknown) => Promise<object>>(
             async () => ({}),
         ),
@@ -128,6 +149,110 @@ describe("get", () => {
         expect(client.close).toHaveBeenCalled();
 
         logSpy.mockRestore();
+    });
+});
+
+describe("list", () => {
+    test("returns the paginated slice with the total and applies pagination", async () => {
+        const { cursor, collection, repository } = makeFakeMongo();
+        const games = [
+            makeActiveGame({ _id: "alpha" }),
+            makeActiveGame({ _id: "bravo" }),
+        ];
+
+        collection.countDocuments.mockResolvedValue(25);
+        cursor.toArray.mockResolvedValue(games);
+
+        const result = await repository.list({ page: 2, pageSize: 10 });
+
+        expect(result).toEqual(MakeRight({ games, total: 25, page: 2 }));
+        expect(collection.countDocuments).toHaveBeenCalledWith({});
+        expect(collection.find).toHaveBeenCalledWith({});
+        expect(cursor.sort).toHaveBeenCalledWith({ _id: 1 });
+        expect(cursor.skip).toHaveBeenCalledWith(10);
+        expect(cursor.limit).toHaveBeenCalledWith(10);
+    });
+
+    test("builds a case-insensitive regex filter from a trimmed search term", async () => {
+        const { collection, repository } = makeFakeMongo();
+
+        collection.countDocuments.mockResolvedValue(1);
+
+        await repository.list({ search: "  Alpha  ", page: 1, pageSize: 10 });
+
+        expect(collection.find).toHaveBeenCalledWith({
+            _id: { $regex: "Alpha", $options: "i" },
+        });
+    });
+
+    test("escapes regex metacharacters in the search term", async () => {
+        const { collection, repository } = makeFakeMongo();
+
+        collection.countDocuments.mockResolvedValue(0);
+
+        const result = await repository.list({
+            search: "a(b)[c].*",
+            page: 1,
+            pageSize: 10,
+        });
+
+        // Must not throw and must escape every metacharacter.
+        expect(isRight(result)).toBe(true);
+        expect(collection.find).toHaveBeenCalledWith({
+            _id: {
+                $regex: "a\\(b\\)\\[c\\]\\.\\*",
+                $options: "i",
+            },
+        });
+    });
+
+    test("treats a whitespace-only search as no filter", async () => {
+        const { collection, repository } = makeFakeMongo();
+
+        collection.countDocuments.mockResolvedValue(3);
+
+        await repository.list({ search: "   ", page: 1, pageSize: 10 });
+
+        expect(collection.find).toHaveBeenCalledWith({});
+    });
+
+    test("clamps an out-of-range page down to the last available page", async () => {
+        const { cursor, collection, repository } = makeFakeMongo();
+
+        // 5 games, 10 per page => only 1 page exists.
+        collection.countDocuments.mockResolvedValue(5);
+
+        const result = await repository.list({ page: 999, pageSize: 10 });
+
+        expect(isRight(result)).toBe(true);
+        if (isRight(result)) {
+            expect(result.right.page).toBe(1);
+        }
+        // skip is never negative and never past the results.
+        expect(cursor.skip).toHaveBeenCalledWith(0);
+    });
+
+    test("returns an empty page with page 1 when there are no games", async () => {
+        const { cursor, collection, repository } = makeFakeMongo();
+
+        collection.countDocuments.mockResolvedValue(0);
+        cursor.toArray.mockResolvedValue([]);
+
+        const result = await repository.list({ page: 3, pageSize: 10 });
+
+        expect(result).toEqual(MakeRight({ games: [], total: 0, page: 1 }));
+        expect(cursor.skip).toHaveBeenCalledWith(0);
+    });
+
+    test("returns the error message when the query fails", async () => {
+        const { collection, client, repository } = makeFakeMongo();
+
+        collection.countDocuments.mockRejectedValue(new Error("List failed"));
+
+        const result = await repository.list({ page: 1, pageSize: 10 });
+
+        expect(result).toEqual(MakeLeft("List failed"));
+        expect(client.close).toHaveBeenCalled();
     });
 });
 

--- a/__test__/server/turn/toGameSummary.test.ts
+++ b/__test__/server/turn/toGameSummary.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "@jest/globals";
+import { Game } from "@fc/types/types";
+import { toGameSummary } from "@fc/server/turn";
+import {
+    makeActiveGame,
+    makeInactiveGame,
+    setupInformation,
+} from "../../fixtures/game";
+
+describe("toGameSummary", () => {
+    test("summarises an active game from its live turn information", () => {
+        const game = makeActiveGame({
+            _id: "alpha",
+            turnInformation: {
+                turnNumber: 3,
+                currentPhase: 2,
+                phaseEnd: new Date().toString(),
+            },
+        });
+
+        expect(toGameSummary(game)).toEqual({
+            code: "alpha",
+            gameName: "TEST GAME",
+            turnNumber: 3,
+            phaseNumber: 2,
+            phaseName: "Phase 2",
+            totalPhases: 3,
+            paused: false,
+        });
+    });
+
+    test("summarises a paused game from its frozen turn, not turnInformation", () => {
+        // The live turnInformation deliberately disagrees with the frozen turn
+        // so we can prove the summary uses the frozen (displayed) values.
+        const game = makeInactiveGame(
+            {
+                _id: "bravo",
+                turnInformation: {
+                    turnNumber: 9,
+                    currentPhase: 3,
+                    phaseEnd: new Date().toString(),
+                },
+            },
+            { turnNumber: 2, phase: 1 },
+        );
+
+        expect(toGameSummary(game)).toEqual({
+            code: "bravo",
+            gameName: "TEST GAME",
+            turnNumber: 2,
+            phaseNumber: 1,
+            phaseName: "Phase 1",
+            totalPhases: 3,
+            paused: true,
+        });
+    });
+
+    test("falls back to Unknown when the phase index is out of range", () => {
+        const game = makeActiveGame({
+            _id: "charlie",
+            turnInformation: {
+                turnNumber: 1,
+                currentPhase: 99,
+                phaseEnd: new Date().toString(),
+            },
+        });
+
+        const summary = toGameSummary(game);
+
+        expect(summary.phaseName).toBe("Unknown");
+        expect(summary.totalPhases).toBe(3);
+    });
+
+    test("degrades gracefully for a game with no phases", () => {
+        const game = makeActiveGame({
+            _id: "delta",
+            setupInformation: { ...setupInformation, phases: [] },
+        });
+
+        const summary = toGameSummary(game);
+
+        expect(summary.phaseName).toBe("Unknown");
+        expect(summary.totalPhases).toBe(0);
+    });
+
+    test("falls back to the code when the game name is missing", () => {
+        const game = {
+            ...makeActiveGame({ _id: "echo" }),
+            setupInformation: undefined,
+        } as unknown as Game;
+
+        const summary = toGameSummary(game);
+
+        expect(summary.gameName).toBe("echo");
+        expect(summary.phaseName).toBe("Unknown");
+        expect(summary.totalPhases).toBe(0);
+    });
+});

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -90,21 +90,19 @@ test.describe("admin", () => {
         ).toBeVisible();
 
         // The filler games guarantee more than one page regardless of what
-        // other (parallel) specs have upserted, so Previous is disabled (a
-        // non-link span) and Next is an available link on the first page.
-        await expect(page.getByText("← Previous")).toBeVisible();
-        await expect(
-            page.getByRole("link", { name: "← Previous" }),
-        ).toHaveCount(0);
-        const nextLink = page.getByRole("link", { name: "Next →" });
-        await expect(nextLink).toBeVisible();
+        // other (parallel) specs have upserted, so Previous is disabled and
+        // Next is enabled on the first page.
+        const prevButton = page.getByRole("button", { name: "← Previous" });
+        const nextButton = page.getByRole("button", { name: "Next →" });
+        await expect(prevButton).toBeDisabled();
+        await expect(nextButton).toBeEnabled();
 
-        await nextLink.click();
+        await nextButton.click();
         await expect(page).toHaveURL(/[?&]page=2\b/);
-        // Previous is now an active link (we left page 1).
+        // Previous is now enabled (we left page 1).
         await expect(
-            page.getByRole("link", { name: "← Previous" }),
-        ).toBeVisible();
+            page.getByRole("button", { name: "← Previous" }),
+        ).toBeEnabled();
 
         // Search by code narrows to the paused game. Its unique code can't
         // collide with filler ids or namespaced games from other specs. The

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Page } from "./fixtures";
+import { test, expect } from "./fixtures";
+import { type Page } from "@playwright/test";
 import { projectGameId } from "./helpers";
 import { ADMIN_USERNAME, DEFAULT_PASSWORD, games } from "./seed";
 

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -1,6 +1,25 @@
-import { test, expect } from "./fixtures";
+import { test, expect, type Page } from "./fixtures";
 import { projectGameId } from "./helpers";
-import { ADMIN_USERNAME, DEFAULT_PASSWORD } from "./seed";
+import { ADMIN_USERNAME, DEFAULT_PASSWORD, games } from "./seed";
+
+// The e2e server runs over http://localhost with a Secure iron-session cookie
+// (production build). WebKit refuses to store Secure cookies over plain http
+// (Chromium treats localhost as secure), so any admin flow that needs a session
+// is skipped there - it's a test-server artifact only. Auth is covered by the
+// Chromium projects.
+async function loginAsAdmin(page: Page): Promise<void> {
+    await page.goto("/admin/login");
+    await page.getByLabel("Username").fill(ADMIN_USERNAME);
+    await page.getByLabel("Password").fill(DEFAULT_PASSWORD);
+
+    const [loginResponse] = await Promise.all([
+        page.waitForResponse((response) =>
+            response.url().includes("/api/login"),
+        ),
+        page.getByRole("button", { name: "Login" }).click(),
+    ]);
+    expect(loginResponse.status()).toBe(200);
+}
 
 test.describe("admin", () => {
     test("unauthenticated admin redirects to login", async ({ page }) => {
@@ -13,30 +32,12 @@ test.describe("admin", () => {
         page,
         browserName,
     }, testInfo) => {
-        // The e2e server runs over http://localhost, and the iron-session
-        // cookie is Secure (production build). WebKit refuses to store Secure
-        // cookies over plain http (Chromium treats localhost as secure), so the
-        // session can't be established here. This is a test-server artifact
-        // only - production runs over HTTPS. Auth is covered by the Chromium
-        // projects.
         test.skip(
             browserName === "webkit",
             "WebKit drops Secure cookies over http://localhost",
         );
 
-        await page.goto("/admin/login");
-
-        await page.getByLabel("Username").fill(ADMIN_USERNAME);
-        await page.getByLabel("Password").fill(DEFAULT_PASSWORD);
-
-        // Log in and confirm the request succeeded (the session cookie is set).
-        const [loginResponse] = await Promise.all([
-            page.waitForResponse((response) =>
-                response.url().includes("/api/login"),
-            ),
-            page.getByRole("button", { name: "Login" }).click(),
-        ]);
-        expect(loginResponse.status()).toBe(200);
+        await loginAsAdmin(page);
 
         // The protected dashboard is now reachable, proving the session works
         // (the middleware would otherwise bounce us back to /admin/login).
@@ -64,5 +65,85 @@ test.describe("admin", () => {
         await status.getByRole("link", { name: `/game/${gameId}` }).click();
         await expect(page).toHaveURL(new RegExp(`/game/${gameId}$`));
         await expect(page.getByRole("main")).toBeVisible();
+    });
+
+    test("lists games with search, pagination and share links", async ({
+        page,
+        browserName,
+    }) => {
+        test.skip(
+            browserName === "webkit",
+            "WebKit drops Secure cookies over http://localhost",
+        );
+
+        await loginAsAdmin(page);
+
+        await page.goto("/admin/game");
+        await expect(
+            page.getByRole("heading", { name: "Games" }),
+        ).toBeVisible();
+
+        // A known seeded game is listed.
+        await expect(
+            page.getByText(games.firstContact, { exact: true }),
+        ).toBeVisible();
+
+        // The filler games guarantee more than one page regardless of what
+        // other (parallel) specs have upserted, so Previous is disabled (a
+        // non-link span) and Next is an available link on the first page.
+        await expect(page.getByText("← Previous")).toBeVisible();
+        await expect(
+            page.getByRole("link", { name: "← Previous" }),
+        ).toHaveCount(0);
+        const nextLink = page.getByRole("link", { name: "Next →" });
+        await expect(nextLink).toBeVisible();
+
+        await nextLink.click();
+        await expect(page).toHaveURL(/[?&]page=2\b/);
+        // Previous is now an active link (we left page 1).
+        await expect(
+            page.getByRole("link", { name: "← Previous" }),
+        ).toBeVisible();
+
+        // Search by code narrows to the paused game. Its unique code can't
+        // collide with filler ids or namespaced games from other specs. The
+        // input is debounced, so wait for the resulting navigation to land
+        // (which also drops the page param, resetting to page 1).
+        await page.getByPlaceholder("Search by code…").fill(games.paused);
+        await expect(page).toHaveURL(new RegExp(`search=${games.paused}`));
+        await expect(
+            page.getByRole("button", { name: "Links & QR" }),
+        ).toHaveCount(1);
+        await expect(
+            page.getByText(games.paused, { exact: true }),
+        ).toBeVisible();
+        await expect(
+            page.getByText(games.firstContact, { exact: true }),
+        ).toHaveCount(0);
+        // The paused seed game reports its state (and turn/phase) from the
+        // frozen turn: turn 1, phase 1 ("Team Time"), paused.
+        await expect(
+            page.getByText("Turn 1 · Team Time (Phase 1) · Paused"),
+        ).toBeVisible();
+
+        // Open the share modal and confirm all three view links + QR codes.
+        // (Scope queries to the dialog; the Headless UI dialog role sits on a
+        // zero-size relative wrapper, so assert visibility on its content.)
+        await page.getByRole("button", { name: "Links & QR" }).click();
+        const dialog = page.getByRole("dialog");
+
+        // Only the player code ends exactly at the game id; control/press add a
+        // suffix, so each regex matches exactly one <code>.
+        await expect(
+            dialog.getByText(new RegExp(`/game/${games.paused}$`)),
+        ).toBeVisible();
+        await expect(
+            dialog.getByText(new RegExp(`/game/${games.paused}/control$`)),
+        ).toBeVisible();
+        await expect(
+            dialog.getByText(new RegExp(`/game/${games.paused}/press$`)),
+        ).toBeVisible();
+        // react-qr-code renders an <svg> per view.
+        await expect(dialog.locator("svg")).toHaveCount(3);
     });
 });

--- a/e2e/seed.ts
+++ b/e2e/seed.ts
@@ -82,8 +82,35 @@ const defconComponent: Game["components"][number] = {
     },
 };
 
+/**
+ * Filler games so the admin games list (page size 20) always has more than one
+ * page, regardless of how many extra documents parallel mutating specs upsert.
+ * Their ids share a prefix that no other seed/spec id contains, so a search for
+ * a specific code never accidentally matches them.
+ */
+export const LIST_FILLER_COUNT = 20;
+
+function listFillerGames(): Game[] {
+    return Array.from({ length: LIST_FILLER_COUNT }, (_unused, index) => {
+        const id = `e2e-list-fill-${String(index + 1).padStart(2, "0")}`;
+        return activeGame(
+            id,
+            {
+                gameName: `E2E List Filler ${index + 1}`,
+                theme: "first-contact",
+                breakingNewsBanner: false,
+                components: [],
+                phases: standardPhases,
+                press: false,
+            },
+            [],
+        );
+    });
+}
+
 function buildGames(): Game[] {
     return [
+        ...listFillerGames(),
         // Player display + press submit. Has a Defcon component (→ "Defcon" tab)
         // and single-press (→ "Press" tab).
         activeGame(

--- a/src/app/admin/game/GameShareModal.tsx
+++ b/src/app/admin/game/GameShareModal.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+import QRCode from "react-qr-code";
+import { gameUrls, GameUrls } from "@fc/lib/gameUrls";
+
+const VIEWS: { key: keyof GameUrls; label: string }[] = [
+    { key: "control", label: "Control" },
+    { key: "press", label: "Press" },
+    { key: "player", label: "Player" },
+];
+
+function ShareView({
+    label,
+    url,
+}: {
+    label: string;
+    url: string;
+}): React.ReactElement {
+    const [copied, setCopied] = useState<boolean>(false);
+    const [copyFailed, setCopyFailed] = useState<boolean>(false);
+
+    const copy = async () => {
+        setCopied(false);
+        setCopyFailed(false);
+
+        // `navigator.clipboard` is undefined outside a secure context (e.g. a
+        // venue LAN served over plain HTTP), so guard before using it and fall
+        // back to telling the operator to copy the visible URL / scan the QR.
+        if (navigator.clipboard?.writeText) {
+            try {
+                await navigator.clipboard.writeText(url);
+                setCopied(true);
+                return;
+            } catch {
+                // fall through to the failure message
+            }
+        }
+
+        setCopyFailed(true);
+    };
+
+    return (
+        <div className="flex flex-col items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-950 p-4">
+            <h3 className="text-sm font-semibold text-zinc-200">{label}</h3>
+            <div className="bg-white p-3">
+                <QRCode value={url} size={140} />
+            </div>
+            <code className="w-full break-all text-center text-xs text-zinc-400">
+                {url}
+            </code>
+            <button
+                type="button"
+                onClick={copy}
+                className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-indigo-500"
+            >
+                {copied ? "Copied!" : "Copy link"}
+            </button>
+            {copyFailed ? (
+                <p className="text-xs text-amber-300">
+                    Copy failed — select the URL above or scan the QR code.
+                </p>
+            ) : null}
+        </div>
+    );
+}
+
+export default function GameShareModal({
+    code,
+}: {
+    code: string;
+}): React.ReactElement {
+    const [open, setOpen] = useState<boolean>(false);
+    const [urls, setUrls] = useState<GameUrls | null>(null);
+
+    const openModal = () => {
+        // `window` is only available on the client; reading it here (on click,
+        // well after hydration) keeps this SSR-safe.
+        if (typeof window !== "undefined") {
+            setUrls(gameUrls(window.location.origin, code));
+        }
+        setOpen(true);
+    };
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={openModal}
+                className="rounded-md border border-zinc-600 bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition hover:border-indigo-500 hover:text-white"
+            >
+                Links &amp; QR
+            </button>
+            <Dialog
+                open={open}
+                onClose={() => setOpen(false)}
+                className="relative z-50"
+            >
+                <div className="fixed inset-0 bg-black/70" aria-hidden="true" />
+                <div className="fixed inset-0 flex items-center justify-center p-4">
+                    <DialogPanel className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-xl border border-zinc-800 bg-zinc-900 p-6 text-zinc-100">
+                        <div className="flex items-start justify-between">
+                            <DialogTitle className="text-lg font-semibold">
+                                Share links for{" "}
+                                <span className="font-mono text-indigo-300">
+                                    {code}
+                                </span>
+                            </DialogTitle>
+                            <button
+                                type="button"
+                                onClick={() => setOpen(false)}
+                                className="text-zinc-400 transition hover:text-zinc-100"
+                                aria-label="Close"
+                            >
+                                ✕
+                            </button>
+                        </div>
+                        <div className="mt-6 grid gap-4 sm:grid-cols-3">
+                            {urls
+                                ? VIEWS.map(({ key, label }) => (
+                                      <ShareView
+                                          key={key}
+                                          label={label}
+                                          url={urls[key]}
+                                      />
+                                  ))
+                                : null}
+                        </div>
+                    </DialogPanel>
+                </div>
+            </Dialog>
+        </>
+    );
+}

--- a/src/app/admin/game/GamesPagination.tsx
+++ b/src/app/admin/game/GamesPagination.tsx
@@ -16,17 +16,26 @@ function targetHref(search: string | undefined, page: number): string {
 export default function GamesPagination({
     page,
     totalPages,
+    pageSize,
     count,
     total,
     search,
 }: {
     page: number;
     totalPages: number;
+    pageSize: number;
     count: number;
     total: number;
     search?: string;
 }): React.ReactElement {
     const router = useRouter();
+
+    // The 1-indexed range of items shown on this page, e.g. "11-20" (or just
+    // "5" when the page holds a single item).
+    const rangeStart = (page - 1) * pageSize + 1;
+    const rangeEnd = rangeStart + count - 1;
+    const range =
+        rangeStart === rangeEnd ? `${rangeStart}` : `${rangeStart}-${rangeEnd}`;
     // Navigate inside a transition so the current list stays visible (rather
     // than flashing the skeleton) while `isPending` drives a clear indicator
     // that a new query is running.
@@ -69,7 +78,7 @@ export default function GamesPagination({
                     <>
                         Page {page} of {totalPages}
                         {total > 0
-                            ? ` · ${count} of ${total} game${total === 1 ? "" : "s"}`
+                            ? ` · ${range} of ${total} game${total === 1 ? "" : "s"}`
                             : ""}
                     </>
                 )}

--- a/src/app/admin/game/GamesPagination.tsx
+++ b/src/app/admin/game/GamesPagination.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+function targetHref(search: string | undefined, page: number): string {
+    const params = new URLSearchParams();
+    const trimmed = search?.trim();
+    if (trimmed) {
+        params.set("search", trimmed);
+    }
+    params.set("page", String(page));
+    return `/admin/game?${params.toString()}`;
+}
+
+export default function GamesPagination({
+    page,
+    totalPages,
+    total,
+    search,
+}: {
+    page: number;
+    totalPages: number;
+    total: number;
+    search?: string;
+}): React.ReactElement {
+    const router = useRouter();
+    // Navigate inside a transition so the current list stays visible (rather
+    // than flashing the skeleton) while `isPending` drives a clear indicator
+    // that a new query is running.
+    const [isPending, startTransition] = useTransition();
+
+    const go = (targetPage: number) => {
+        startTransition(() => {
+            router.push(targetHref(search, targetPage));
+        });
+    };
+
+    const buttonClass = (disabled: boolean) =>
+        disabled
+            ? "cursor-not-allowed rounded-lg border border-zinc-800 px-4 py-2 text-zinc-600"
+            : "rounded-lg border border-zinc-700 px-4 py-2 text-zinc-200 transition hover:border-indigo-500 hover:text-white";
+
+    return (
+        <div
+            className="mt-6 flex items-center justify-between text-sm"
+            aria-busy={isPending}
+        >
+            <button
+                type="button"
+                onClick={() => go(page - 1)}
+                disabled={page <= 1 || isPending}
+                className={buttonClass(page <= 1 || isPending)}
+            >
+                ← Previous
+            </button>
+            <span className="flex items-center gap-2 text-zinc-400">
+                {isPending ? (
+                    <>
+                        <span
+                            className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-600 border-t-indigo-400"
+                            aria-hidden="true"
+                        />
+                        <span role="status">Loading…</span>
+                    </>
+                ) : (
+                    <>
+                        Page {page} of {totalPages}
+                        {total > 0
+                            ? ` · ${total} game${total === 1 ? "" : "s"}`
+                            : ""}
+                    </>
+                )}
+            </span>
+            <button
+                type="button"
+                onClick={() => go(page + 1)}
+                disabled={page >= totalPages || isPending}
+                className={buttonClass(page >= totalPages || isPending)}
+            >
+                Next →
+            </button>
+        </div>
+    );
+}

--- a/src/app/admin/game/GamesPagination.tsx
+++ b/src/app/admin/game/GamesPagination.tsx
@@ -16,11 +16,13 @@ function targetHref(search: string | undefined, page: number): string {
 export default function GamesPagination({
     page,
     totalPages,
+    count,
     total,
     search,
 }: {
     page: number;
     totalPages: number;
+    count: number;
     total: number;
     search?: string;
 }): React.ReactElement {
@@ -67,7 +69,7 @@ export default function GamesPagination({
                     <>
                         Page {page} of {totalPages}
                         {total > 0
-                            ? ` · ${total} game${total === 1 ? "" : "s"}`
+                            ? ` · ${count} of ${total} game${total === 1 ? "" : "s"}`
                             : ""}
                     </>
                 )}

--- a/src/app/admin/game/GamesSearch.tsx
+++ b/src/app/admin/game/GamesSearch.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function GamesSearch(): React.ReactElement {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const [value, setValue] = useState<string>(
+        () => searchParams?.get("search") ?? "",
+    );
+    const [isPending, startTransition] = useTransition();
+
+    // Debounce navigation so we don't push (and re-query) on every keystroke.
+    // A new search drops the `page` param, resetting to page 1.
+    useEffect(() => {
+        const handle = setTimeout(() => {
+            const current = searchParams?.get("search") ?? "";
+            const next = value.trim();
+
+            if (next === current) {
+                return;
+            }
+
+            const params = new URLSearchParams();
+            if (next) {
+                params.set("search", next);
+            }
+            const query = params.toString();
+
+            startTransition(() => {
+                router.push(`/admin/game${query ? `?${query}` : ""}`);
+            });
+        }, 300);
+
+        return () => clearTimeout(handle);
+    }, [value, searchParams, router]);
+
+    return (
+        <div className="relative">
+            <label htmlFor="game-search" className="sr-only">
+                Search by code
+            </label>
+            <input
+                id="game-search"
+                type="search"
+                value={value}
+                onChange={(event) => setValue(event.target.value)}
+                placeholder="Search by code…"
+                className="block w-full rounded-lg border-zinc-700 bg-zinc-950 text-zinc-100 placeholder-zinc-500 focus:border-indigo-500 focus:ring-indigo-500"
+            />
+            {isPending ? (
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-zinc-500">
+                    Searching…
+                </span>
+            ) : null}
+        </div>
+    );
+}

--- a/src/app/admin/game/loading.tsx
+++ b/src/app/admin/game/loading.tsx
@@ -1,0 +1,39 @@
+// Shown instantly (via the App Router Suspense boundary) while the async
+// server component in page.tsx waits on the games query, so the initial load
+// doesn't feel like a blank stall. Mirrors the real page layout.
+export default function Loading(): React.ReactElement {
+    return (
+        <div aria-busy="true">
+            <h1 className="text-3xl font-bold">Games</h1>
+            <p className="mt-2 text-zinc-400">
+                Browse existing games and grab share links &amp; QR codes for
+                the control, press, and player views.
+            </p>
+
+            <div className="mt-6 max-w-md">
+                <div className="h-10 w-full animate-pulse rounded-lg bg-zinc-900" />
+            </div>
+
+            <div className="mt-6">
+                <span className="sr-only" role="status">
+                    Loading games…
+                </span>
+                <ul className="divide-y divide-zinc-800 rounded-xl border border-zinc-800 bg-zinc-900">
+                    {Array.from({ length: 6 }).map((_unused, index) => (
+                        <li
+                            key={index}
+                            className="flex items-center justify-between gap-3 p-4"
+                        >
+                            <div className="flex-1 space-y-2">
+                                <div className="h-4 w-32 animate-pulse rounded bg-zinc-800" />
+                                <div className="h-3 w-48 animate-pulse rounded bg-zinc-800" />
+                                <div className="h-3 w-64 animate-pulse rounded bg-zinc-800" />
+                            </div>
+                            <div className="h-8 w-24 animate-pulse rounded-md bg-zinc-800" />
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/src/app/admin/game/page.tsx
+++ b/src/app/admin/game/page.tsx
@@ -1,0 +1,158 @@
+import Link from "next/link";
+import { isLeft } from "fp-ts/Either";
+import { getGameRepo } from "@fc/server/repository/game";
+import { GameSummary, toGameSummary } from "@fc/server/turn";
+import GamesSearch from "./GamesSearch";
+import GameShareModal from "./GameShareModal";
+
+const PAGE_SIZE = 20;
+
+function ErrorBanner({ message }: { message: string }): React.ReactElement {
+    return (
+        <div
+            role="alert"
+            className="rounded-lg border border-red-500/50 bg-red-950/60 p-4 text-sm text-red-200"
+        >
+            Could not load games: {message}
+        </div>
+    );
+}
+
+function statusLine(game: GameSummary): string {
+    const phase = `${game.phaseName} (Phase ${game.phaseNumber})`;
+    const state = game.paused ? "Paused" : "Running";
+    return `Turn ${game.turnNumber} · ${phase} · ${state}`;
+}
+
+function pageHref(search: string | undefined, page: number): string {
+    const params = new URLSearchParams();
+    const trimmed = search?.trim();
+    if (trimmed) {
+        params.set("search", trimmed);
+    }
+    params.set("page", String(page));
+    return `/admin/game?${params.toString()}`;
+}
+
+export default async function GamesPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ search?: string; page?: string }>;
+}): Promise<React.ReactElement> {
+    const { search, page: pageParam } = await searchParams;
+    const requestedPage = Math.max(1, Math.floor(Number(pageParam)) || 1);
+
+    const repo = getGameRepo();
+
+    let content: React.ReactElement;
+
+    if (isLeft(repo)) {
+        content = <ErrorBanner message={repo.left} />;
+    } else {
+        const result = await repo.right.list({
+            search,
+            page: requestedPage,
+            pageSize: PAGE_SIZE,
+        });
+
+        if (isLeft(result)) {
+            content = <ErrorBanner message={result.left} />;
+        } else {
+            const { games, total, page } = result.right;
+            const summaries = games.map(toGameSummary);
+            const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+            content =
+                summaries.length === 0 ? (
+                    <p className="rounded-lg border border-zinc-800 bg-zinc-900 p-6 text-sm text-zinc-400">
+                        No games found.
+                    </p>
+                ) : (
+                    <>
+                        <ul className="divide-y divide-zinc-800 rounded-xl border border-zinc-800 bg-zinc-900">
+                            {summaries.map((game) => (
+                                <li
+                                    key={game.code}
+                                    className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                                >
+                                    <div>
+                                        <p className="font-mono text-base font-semibold text-indigo-300">
+                                            {game.code}
+                                        </p>
+                                        <p className="text-sm text-zinc-300">
+                                            {game.gameName}
+                                        </p>
+                                        <p className="mt-1 text-xs text-zinc-500">
+                                            {statusLine(game)}
+                                        </p>
+                                    </div>
+                                    <GameShareModal code={game.code} />
+                                </li>
+                            ))}
+                        </ul>
+                        <div className="mt-6 flex items-center justify-between text-sm">
+                            <PaginationLink
+                                href={pageHref(search, page - 1)}
+                                disabled={page <= 1}
+                                label="← Previous"
+                            />
+                            <span className="text-zinc-400">
+                                Page {page} of {totalPages}
+                                {total > 0
+                                    ? ` · ${total} game${total === 1 ? "" : "s"}`
+                                    : ""}
+                            </span>
+                            <PaginationLink
+                                href={pageHref(search, page + 1)}
+                                disabled={page >= totalPages}
+                                label="Next →"
+                            />
+                        </div>
+                    </>
+                );
+        }
+    }
+
+    return (
+        <div>
+            <h1 className="text-3xl font-bold">Games</h1>
+            <p className="mt-2 text-zinc-400">
+                Browse existing games and grab share links &amp; QR codes for
+                the control, press, and player views.
+            </p>
+
+            <div className="mt-6 max-w-md">
+                <GamesSearch />
+            </div>
+
+            <div className="mt-6">{content}</div>
+        </div>
+    );
+}
+
+function PaginationLink({
+    href,
+    disabled,
+    label,
+}: {
+    href: string;
+    disabled: boolean;
+    label: string;
+}): React.ReactElement {
+    if (disabled) {
+        return (
+            <span className="cursor-not-allowed rounded-lg border border-zinc-800 px-4 py-2 text-zinc-600">
+                {label}
+            </span>
+        );
+    }
+
+    return (
+        <Link
+            href={href}
+            className="rounded-lg border border-zinc-700 px-4 py-2 text-zinc-200 transition hover:border-indigo-500 hover:text-white"
+        >
+            {label}
+        </Link>
+    );
+}

--- a/src/app/admin/game/page.tsx
+++ b/src/app/admin/game/page.tsx
@@ -5,7 +5,7 @@ import GamesSearch from "./GamesSearch";
 import GamesPagination from "./GamesPagination";
 import GameShareModal from "./GameShareModal";
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 10;
 
 function ErrorBanner({ message }: { message: string }): React.ReactElement {
     return (
@@ -83,6 +83,7 @@ export default async function GamesPage({
                         <GamesPagination
                             page={page}
                             totalPages={totalPages}
+                            count={summaries.length}
                             total={total}
                             search={search}
                         />

--- a/src/app/admin/game/page.tsx
+++ b/src/app/admin/game/page.tsx
@@ -1,8 +1,8 @@
-import Link from "next/link";
 import { isLeft } from "fp-ts/Either";
 import { getGameRepo } from "@fc/server/repository/game";
 import { GameSummary, toGameSummary } from "@fc/server/turn";
 import GamesSearch from "./GamesSearch";
+import GamesPagination from "./GamesPagination";
 import GameShareModal from "./GameShareModal";
 
 const PAGE_SIZE = 20;
@@ -22,16 +22,6 @@ function statusLine(game: GameSummary): string {
     const phase = `${game.phaseName} (Phase ${game.phaseNumber})`;
     const state = game.paused ? "Paused" : "Running";
     return `Turn ${game.turnNumber} · ${phase} · ${state}`;
-}
-
-function pageHref(search: string | undefined, page: number): string {
-    const params = new URLSearchParams();
-    const trimmed = search?.trim();
-    if (trimmed) {
-        params.set("search", trimmed);
-    }
-    params.set("page", String(page));
-    return `/admin/game?${params.toString()}`;
 }
 
 export default async function GamesPage({
@@ -90,24 +80,12 @@ export default async function GamesPage({
                                 </li>
                             ))}
                         </ul>
-                        <div className="mt-6 flex items-center justify-between text-sm">
-                            <PaginationLink
-                                href={pageHref(search, page - 1)}
-                                disabled={page <= 1}
-                                label="← Previous"
-                            />
-                            <span className="text-zinc-400">
-                                Page {page} of {totalPages}
-                                {total > 0
-                                    ? ` · ${total} game${total === 1 ? "" : "s"}`
-                                    : ""}
-                            </span>
-                            <PaginationLink
-                                href={pageHref(search, page + 1)}
-                                disabled={page >= totalPages}
-                                label="Next →"
-                            />
-                        </div>
+                        <GamesPagination
+                            page={page}
+                            totalPages={totalPages}
+                            total={total}
+                            search={search}
+                        />
                     </>
                 );
         }
@@ -127,32 +105,5 @@ export default async function GamesPage({
 
             <div className="mt-6">{content}</div>
         </div>
-    );
-}
-
-function PaginationLink({
-    href,
-    disabled,
-    label,
-}: {
-    href: string;
-    disabled: boolean;
-    label: string;
-}): React.ReactElement {
-    if (disabled) {
-        return (
-            <span className="cursor-not-allowed rounded-lg border border-zinc-800 px-4 py-2 text-zinc-600">
-                {label}
-            </span>
-        );
-    }
-
-    return (
-        <Link
-            href={href}
-            className="rounded-lg border border-zinc-700 px-4 py-2 text-zinc-200 transition hover:border-indigo-500 hover:text-white"
-        >
-            {label}
-        </Link>
     );
 }

--- a/src/app/admin/game/page.tsx
+++ b/src/app/admin/game/page.tsx
@@ -83,6 +83,7 @@ export default async function GamesPage({
                         <GamesPagination
                             page={page}
                             totalPages={totalPages}
+                            pageSize={PAGE_SIZE}
                             count={summaries.length}
                             total={total}
                             search={search}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -31,6 +31,12 @@ export default function AdminLayout({
                             Dashboard
                         </Link>
                         <Link
+                            href="/admin/game"
+                            className="text-zinc-400 transition hover:text-zinc-100"
+                        >
+                            Games
+                        </Link>
+                        <Link
                             href="/admin/game/create"
                             className="text-zinc-400 transition hover:text-zinc-100"
                         >

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,6 +10,21 @@ export default function Page() {
 
             <div className="mt-8 grid gap-4 sm:grid-cols-2">
                 <Link
+                    href="/admin/game"
+                    className="group rounded-xl border border-zinc-800 bg-zinc-900 p-6 transition hover:border-indigo-500/60 hover:bg-zinc-900/60"
+                >
+                    <h2 className="text-lg font-semibold transition group-hover:text-indigo-300">
+                        View games{" "}
+                        <span aria-hidden="true" className="inline-block">
+                            →
+                        </span>
+                    </h2>
+                    <p className="mt-1 text-sm text-zinc-400">
+                        Browse existing games and get share links &amp; QR
+                        codes.
+                    </p>
+                </Link>
+                <Link
                     href="/admin/game/create"
                     className="group rounded-xl border border-zinc-800 bg-zinc-900 p-6 transition hover:border-indigo-500/60 hover:bg-zinc-900/60"
                 >

--- a/src/lib/gameUrls.ts
+++ b/src/lib/gameUrls.ts
@@ -1,0 +1,19 @@
+// Build the shareable URLs for a game's three views. Game codes are
+// unvalidated free strings, so the code must be URL-encoded — otherwise a
+// `#`, `/` or space in a code would corrupt the route (and any QR built from
+// it).
+export type GameUrls = {
+    player: string;
+    control: string;
+    press: string;
+};
+
+export function gameUrls(origin: string, code: string): GameUrls {
+    const base = `${origin}/game/${encodeURIComponent(code)}`;
+
+    return {
+        player: base,
+        control: `${base}/control`,
+        press: `${base}/press`,
+    };
+}

--- a/src/server/repository/game/index.ts
+++ b/src/server/repository/game/index.ts
@@ -2,8 +2,22 @@ import { ControlAction, Game } from "@fc/types/types";
 import { Either } from "fp-ts/Either";
 import { MongoRepository } from "./mongo";
 
+export interface ListGamesOptions {
+    search?: string;
+    page: number;
+    pageSize: number;
+}
+
+export interface ListGamesResult {
+    games: Game[];
+    total: number;
+    // The page actually served, after clamping to the available range.
+    page: number;
+}
+
 export default interface GameRepository {
     get: (id: string) => Promise<Either<false, Game>>;
+    list: (opts: ListGamesOptions) => Promise<Either<string, ListGamesResult>>;
     insert: (game: Game) => Promise<Either<string, true>>;
     nextTurn: (game: Game) => Promise<Either<string, Game>>;
     runControlAction: (

--- a/src/server/repository/game/mongo.ts
+++ b/src/server/repository/game/mongo.ts
@@ -1,11 +1,19 @@
-import GameRepository from "./index";
+import GameRepository, { ListGamesOptions, ListGamesResult } from "./index";
 import { Either, isLeft } from "fp-ts/Either";
 import { ControlAction, Game } from "@fc/types/types";
 import { MakeLeft, MakeRight } from "@fc/lib/io-ts-helpers";
-import { MongoClient } from "mongodb";
+import { Filter, MongoClient } from "mongodb";
 import initialiseMongo, { getCollection } from "../../mongo";
 import { tickTurn } from "../../turn";
 import { isRight } from "fp-ts/lib/Either";
+
+// Escape every regex metacharacter so a game code is matched literally. Without
+// this an unbalanced `(` or `[` in the search term would make Mongo throw.
+function escapeRegex(input: string): string {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const MAX_SEARCH_LENGTH = 64;
 
 export class MongoRepository implements GameRepository {
     constructor(private readonly mongo: MongoClient) {}
@@ -40,6 +48,50 @@ export class MongoRepository implements GameRepository {
         } catch (e) {
             console.log(e);
             return MakeLeft(false);
+        } finally {
+            await this.mongo.close();
+        }
+    }
+
+    async list({
+        search,
+        page,
+        pageSize,
+    }: ListGamesOptions): Promise<Either<string, ListGamesResult>> {
+        try {
+            await this.mongo.connect();
+
+            const database = this.mongo.db();
+
+            const games = getCollection(database, "games");
+
+            const trimmed = (search ?? "").trim().slice(0, MAX_SEARCH_LENGTH);
+            const filter: Filter<Game> =
+                trimmed.length > 0
+                    ? { _id: { $regex: escapeRegex(trimmed), $options: "i" } }
+                    : {};
+
+            const total = await games.countDocuments(filter);
+
+            // Clamp the requested page into the available range so an
+            // out-of-range/NaN page can never produce a negative skip (which
+            // Mongo rejects) or an empty page past the end of the results.
+            const totalPages = Math.max(1, Math.ceil(total / pageSize));
+            const safePage = Math.min(
+                Math.max(1, Math.floor(page) || 1),
+                totalPages,
+            );
+
+            const results = await games
+                .find(filter)
+                .sort({ _id: 1 })
+                .skip((safePage - 1) * pageSize)
+                .limit(pageSize)
+                .toArray();
+
+            return MakeRight({ games: results, total, page: safePage });
+        } catch (e) {
+            return MakeLeft((e as Error).message);
         } finally {
             await this.mongo.close();
         }

--- a/src/server/turn.ts
+++ b/src/server/turn.ts
@@ -85,6 +85,46 @@ export function toApiResponse(
     };
 }
 
+// A lightweight, display-ready view of a game for the admin games list.
+export type GameSummary = {
+    code: string;
+    gameName: string;
+    turnNumber: number;
+    phaseNumber: number; // 1-indexed
+    phaseName: string;
+    totalPhases: number;
+    paused: boolean;
+};
+
+// Map a stored game to its display summary. The turn/phase shown must match
+// what the live views render, so for a paused game we read from `frozenTurn`
+// (exactly what `toApiResponse` returns when `!active`) rather than the live
+// `turnInformation`. Access is defensive because stored games are cast, not
+// decoded, so a legacy/corrupt document must degrade gracefully instead of
+// throwing and taking down the whole list.
+export function toGameSummary(game: Game): GameSummary {
+    const paused = game.active === false;
+
+    const turnNumber = paused
+        ? game.frozenTurn.turnNumber
+        : game.turnInformation.turnNumber;
+    const phaseNumber = paused
+        ? game.frozenTurn.phase
+        : game.turnInformation.currentPhase;
+
+    const phases = game.setupInformation?.phases;
+
+    return {
+        code: game._id,
+        gameName: game.setupInformation?.gameName ?? game._id,
+        turnNumber,
+        phaseNumber,
+        phaseName: phases?.[phaseNumber - 1]?.title ?? "Unknown",
+        totalPhases: phases?.length ?? 0,
+        paused,
+    };
+}
+
 export function nextPhase(phase: number, setup: SetupInformation): number {
     const newPhaseNumber = phase + 1;
 


### PR DESCRIPTION
## What & why

The admin area only let you create a game — there was no way to see which games exist, check their state, or hand out the control/press/player links. This adds a separate **Games** page under `/admin/game`.

It does everything requested:

- **Separate page** — new `/admin/game` route, plus a "Games" nav link and a dashboard card.
- **QR + copy/paste links** — each game has a **Links & QR** button opening a modal with a QR code *and* a copy button for all three views (control, press, player).
- **Code, paused state, turn/phase** — each row shows the code, game name, and a status line like `Turn 1 · Team Time (Phase 1) · Paused` (phase name *and* number).
- **No auto-refresh** — built as a URL-driven server component; only loads on navigation/search.
- **Search by code + pagination** — debounced code search and Prev/Next paging, both done server-side in MongoDB.

## How it's built

- New paginated, code-searchable `list()` on `GameRepository` (Mongo `skip`/`limit` + `countDocuments`, escaped case-insensitive `_id` regex, server-side page clamping).
- Pure `toGameSummary()` mapper in `src/server/turn.ts` that mirrors `toApiResponse`.
- The list page is an async server component; only the search input and the share modal are client components (the modal reuses the existing `react-qr-code` pattern and `@headlessui` `Dialog`).

## Correctness decisions (from a pre-implementation review pass)

- **Paused games read turn/phase from `frozenTurn`**, not the live `turnInformation`, so the list matches what the control/player views actually show.
- Game codes are **URL-encoded** in every link/QR (codes are free-form strings).
- **Defensive access** on `setupInformation`/`phases` so a corrupt/legacy document degrades to "Unknown" instead of crashing the whole page.
- Page numbers are **clamped** server-side (no negative/NaN `skip`); `pageSize` is a server constant, not client-controlled.
- Search term is escaped + trimmed; whitespace-only means no filter.
- `navigator.clipboard` is guarded with a fallback for non-HTTPS venue networks.

## How to test

1. Point at a Mongo with some games (or create a few via **Create game**).
2. Log into `/admin`, open **Games**.
3. Search by a game code — the list filters and resets to page 1.
4. Page through with **Previous / Next** (footer shows `Page X of Y`).
5. Click **Links & QR** on a game — confirm the three view links/QR resolve to `/game/{code}`, `/game/{code}/control`, `/game/{code}/press`, and that copy works.
6. For a **paused** game, confirm the listed turn/phase matches its live view.

## Verification done

- `tsc --noEmit` and ESLint clean.
- All 577 Jest tests pass (new repository, mapper, and fixture tests included).
- Full Playwright e2e suite passes on Desktop Chrome, including a new test covering list/search/pagination/modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCNxd2dHi7dfcYnN7y76cv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCNxd2dHi7dfcYnN7y76cv)_