### PR TITLE
fix(types): make the extraTime codec validate its values

### DIFF
--- a/__test__/types/setup-information-decode.test.ts
+++ b/__test__/types/setup-information-decode.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "@jest/globals";
+import * as t from "io-ts";
+import {
+    ComponentDecode,
+    SetupInformationDecode,
+    SetupInformationPhaseDecode,
+} from "@fc/types/io-ts-def";
+import { GAME_DEFINITIONS } from "@fc/server/game-definitions";
+import { lengthOfPhase, nextDate } from "@fc/server/turn";
+import { isRight } from "fp-ts/Either";
+import { SetupInformation } from "@fc/types/types";
+
+const ComponentsDecode = t.array(ComponentDecode);
+
+function makePhase(
+    overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+    return { title: "Action Phase", length: 10, hidden: false, ...overrides };
+}
+
+describe("SetupInformationDecode", () => {
+    // Nothing in the app decoded setupInformation at runtime until the edit API
+    // (#816), so these codecs had never been exercised against real data. They
+    // are the contract the edit endpoint validates against: if a shipped game
+    // fails to decode, that game becomes uneditable for no visible reason.
+    test.each(Object.entries(GAME_DEFINITIONS))(
+        "accepts the %s definition",
+        (_name, definition) => {
+            expect(SetupInformationDecode.is(definition.setupInformation)).toBe(
+                true,
+            );
+            expect(ComponentsDecode.is(definition.components)).toBe(true);
+        },
+    );
+
+    test("rejects setup information with no phases key", () => {
+        expect(SetupInformationDecode.is({ gameName: "x" })).toBe(false);
+    });
+});
+
+describe("SetupInformationPhaseDecode", () => {
+    test.each([
+        ["a bare phase", makePhase()],
+        ["no extraTime", makePhase()],
+        ["an empty extraTime", makePhase({ extraTime: {} })],
+        ["a numeric-keyed extraTime", makePhase({ extraTime: { 1: 10 } })],
+        [
+            "several extraTime entries",
+            makePhase({ extraTime: { 1: 10, 4: -5 } }),
+        ],
+    ])("accepts %s", (_label, phase) => {
+        expect(SetupInformationPhaseDecode.is(phase)).toBe(true);
+    });
+
+    // These all returned `true` before the domain was changed to `t.string`:
+    // with a `t.number` domain the codomain check was unreachable, so any value
+    // at all was accepted. See the comment on the codec.
+    test.each([
+        [
+            "a string value under a word key",
+            makePhase({ extraTime: { a: "banana" } }),
+        ],
+        [
+            "a string value under a numeric key",
+            makePhase({ extraTime: { 1: "banana" } }),
+        ],
+        ["a null value", makePhase({ extraTime: { 1: null } })],
+        ["a nested object value", makePhase({ extraTime: { 1: { 2: 3 } } })],
+        ["a boolean value", makePhase({ extraTime: { 1: true } })],
+    ])("rejects extraTime with %s", (_label, phase) => {
+        expect(SetupInformationPhaseDecode.is(phase)).toBe(false);
+    });
+
+    test("rejects a phase whose length is not a number", () => {
+        expect(
+            SetupInformationPhaseDecode.is(makePhase({ length: "10" })),
+        ).toBe(false);
+    });
+});
+
+describe("the bug the extraTime domain guards against", () => {
+    // Regression cover for the failure mode, not just the codec: a non-numeric
+    // extraTime value made `lengthOfPhase` concatenate strings, so `nextDate`
+    // produced an Invalid Date. Stored as `turnInformation.phaseEnd`, that made
+    // `hasFinished` permanently false - a frozen timer with no way back.
+    const poisoned = {
+        gameName: "Poisoned",
+        theme: "first-contact",
+        breakingNewsBanner: false,
+        components: [],
+        phases: [makePhase({ length: 1, extraTime: { 1: "banana" } })],
+    };
+
+    test("the poisoned shape no longer decodes", () => {
+        expect(SetupInformationDecode.is(poisoned)).toBe(false);
+    });
+
+    test("string concatenation produced an Invalid Date when it did decode", () => {
+        // Cast past the codec to demonstrate what used to get through, so the
+        // consequence stays documented even though the door is now shut.
+        const setup = poisoned as unknown as SetupInformation;
+
+        const length = lengthOfPhase(1, 1, setup);
+        expect(isRight(length) && length.right).toBe("1banana");
+
+        const date = nextDate(1, 1, setup);
+        expect(isRight(date) && Number.isNaN(date.right.getTime())).toBe(true);
+    });
+});

--- a/src/types/io-ts-def.ts
+++ b/src/types/io-ts-def.ts
@@ -207,7 +207,23 @@ export const SetupInformationPhaseDecode = t.intersection([
         hidden: t.boolean,
     }),
     t.partial({
-        extraTime: t.record(t.number, t.number),
+        // The domain is `t.string`, not `t.number`, even though the keys are
+        // logically turn numbers. io-ts's `record` only builds a strict props
+        // codec when `getDomainKeys(domain)` yields keys (literals, `keyof`, or
+        // unions of those); `t.number` yields none, so it falls back to
+        // `nonEnumerableRecord`, whose check is
+        //     Object.keys(u).every(k => !domain.is(k) || codomain.is(u[k]))
+        // Object keys are always strings and `t.number.is("1")` is false, so
+        // `!domain.is(k)` was always true and the codomain was NEVER checked -
+        // `extraTime: {a: "banana"}` passed validation. That reached
+        // `lengthOfPhase` as `length += "banana"`, so `nextDate` stored
+        // `phaseEnd: "Invalid Date"`, which makes `hasFinished` permanently
+        // false and freezes the game's timer with no route to recovery.
+        //
+        // A `t.string` domain matches every key, so the value check actually
+        // runs. `extraTime?.[turn]` still type-checks because TypeScript allows
+        // numeric indexing of a string index signature.
+        extraTime: t.record(t.string, t.number),
     }),
     t.partial({
         logo: t.string,


### PR DESCRIPTION
Closes #817. First of seven phases in #816.

## The bug

`SetupInformationPhaseDecode` declared `extraTime: t.record(t.number, t.number)`. io-ts only builds a strict props codec when `getDomainKeys(domain)` yields keys (literals, `keyof`, or unions of those). `t.number` yields none, so it fell back to `nonEnumerableRecord`, whose check is:

```js
Object.keys(u).every(k => !domain.is(k) || codomain.is(u[k]))
```

Object keys are always strings and `t.number.is("1")` is `false`, so `!domain.is(k)` was always true and **the codomain was never checked**. Every possible value passed.

That isn't academic. A non-numeric value reached `lengthOfPhase` (`src/server/turn.ts:28`) as `length += "banana"`, so `nextDate` returned an Invalid Date, which got stored as `turnInformation.phaseEnd`. `hasFinished` then evaluated `new Date("Invalid Date") < new Date()` as `false` — permanently — freezing the game's timer with no route to recovery from the UI.

Verified before writing the fix:

```
SetupInformationPhaseDecode.is({…, extraTime: {a: "banana"}})  ->  true
lengthOfPhase(1, 1, setup)                                     ->  Right("1banana")
nextDate(1, 1, setup)                                          ->  Right(Invalid Date)
```

## The fix

Switch the domain to `t.string`, which matches every key so the value check actually runs. `extraTime?.[turn]` still type-checks because TypeScript allows numeric indexing of a string index signature.

| input | before | after |
| --- | --- | --- |
| `{a: "banana"}` | `true` | `false` |
| `{1: "banana"}` | `true` | `false` |
| `{1: null}` / `{1: true}` / `{1: {2: 3}}` | `true` | `false` |
| `{1: 10}` | `true` | `true` |
| `{1: 10, 4: -5}` | `true` | `true` |
| `{}` / absent | `true` | `true` |
| `dow-new-eden` phases 1–2 | `true` | `true` |
| `faes-anatomy` phases 1–2 | `true` | `true` |

Note the direction of the old bug: the vacuous predicate was *permissive*, not restrictive, so no shipped definition was ever rejected. Nothing in the app decoded `setupInformation` at runtime, which is why this never surfaced — the edit API in #816 will be the first caller to put client-supplied data through this codec, so it needs to be real first.

## Tests

New `__test__/types/setup-information-decode.test.ts` (27 cases), following the `__test__/types/game-type-decode.test.ts` pattern:

- every one of the thirteen shipped definitions decodes, for both `setupInformation` and `components` — this is the contract the edit endpoint will validate against, so a game that fails here would silently become uneditable;
- the negative cases that flip from `true` to `false`, with a comment recording that they used to pass;
- regression cover for the failure mode itself, not just the codec: `lengthOfPhase` returning `"1banana"` and `nextDate` returning an Invalid Date, asserted by casting past the codec so the consequence stays documented even though the door is now shut.

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 44 suites / 701 tests passing
- `npx prettier --check` — clean

No behaviour change for any valid game; the only observable difference is that malformed `extraTime` is now rejected instead of silently bricking the timer.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9)_