### PR TITLE
feat(types): add a lastUpdated stamp and split the frozen-turn codec

### DIFF
--- a/__test__/app/game/api.test.ts
+++ b/__test__/app/game/api.test.ts
@@ -84,6 +84,7 @@ describe("GET /game/[id]/api", () => {
             turnNumber: 1,
             phase: 1,
             phaseEnd: 65,
+            lastUpdated: 0,
         });
         expect(repo.nextTurn).not.toHaveBeenCalled();
     });
@@ -122,6 +123,7 @@ describe("GET /game/[id]/api", () => {
             turnNumber: 1,
             phase: 2,
             phaseEnd: 120,
+            lastUpdated: 0,
         });
     });
 
@@ -153,6 +155,7 @@ describe("GET /game/[id]/api", () => {
             turnNumber: 1,
             phase: 1,
             phaseEnd: 0,
+            lastUpdated: 0,
         });
     });
 
@@ -187,6 +190,7 @@ describe("GET /game/[id]/api", () => {
             turnNumber: 1,
             phase: 3,
             phaseEnd: 0,
+            lastUpdated: 0,
         });
     });
 
@@ -204,6 +208,7 @@ describe("GET /game/[id]/api", () => {
             turnNumber: 1,
             phase: 1,
             phaseEnd: 60,
+            lastUpdated: 0,
         });
         expect(repo.nextTurn).not.toHaveBeenCalled();
     });

--- a/__test__/app/game/control/api.test.ts
+++ b/__test__/app/game/control/api.test.ts
@@ -132,6 +132,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 1,
                 phaseEnd: 65,
+                lastUpdated: 0,
             });
         });
     });
@@ -155,6 +156,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 1,
                 phaseEnd: 60,
+                lastUpdated: 0,
             });
         });
 
@@ -175,6 +177,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 1,
                 phaseEnd: 65,
+                lastUpdated: 0,
             });
         });
     });
@@ -197,6 +200,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 2,
                 phaseEnd: 120,
+                lastUpdated: 0,
             });
         });
 
@@ -218,6 +222,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 2,
                 phase: 1,
                 phaseEnd: 60,
+                lastUpdated: 0,
             });
         });
 
@@ -239,6 +244,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 1,
                 phaseEnd: 60,
+                lastUpdated: 0,
             });
         });
     });
@@ -262,6 +268,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 2,
                 phaseEnd: 120,
+                lastUpdated: 0,
             });
         });
 
@@ -284,6 +291,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 3,
                 phaseEnd: 180,
+                lastUpdated: 0,
             });
         });
 
@@ -306,6 +314,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 1,
                 phaseEnd: 60,
+                lastUpdated: 0,
             });
         });
     });
@@ -330,6 +339,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 2,
                 phase: 1,
                 phaseEnd: 60,
+                lastUpdated: 0,
             });
         });
 
@@ -349,6 +359,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 1,
                 phase: 1,
                 phaseEnd: 60,
+                lastUpdated: 0,
             });
         });
     });
@@ -372,6 +383,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 2,
                 phase: 1,
                 phaseEnd: 60,
+                lastUpdated: 0,
             });
         });
 
@@ -398,6 +410,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 2,
                 phase: 1,
                 phaseEnd: 60,
+                lastUpdated: 0,
             });
         });
     });
@@ -430,6 +443,7 @@ describe("POST /game/[id]/control/api", () => {
                 turnNumber: 2,
                 phase: 3,
                 phaseEnd: 65,
+                lastUpdated: 0,
             });
         });
     });

--- a/__test__/app/game/press.test.ts
+++ b/__test__/app/game/press.test.ts
@@ -129,6 +129,7 @@ describe("POST /game/[id]/press/api", () => {
             turnNumber: 1,
             phase: 1,
             phaseEnd: 65,
+            lastUpdated: 0,
         });
     });
 

--- a/__test__/components/GameWrapper.test.tsx
+++ b/__test__/components/GameWrapper.test.tsx
@@ -163,6 +163,7 @@ describe("GameWrapper poll interval", () => {
             breakingNews: [],
             active: true,
             phaseEnd: 0,
+            lastUpdated: 0,
             components: [],
         };
         (global as unknown as { fetch: unknown }).fetch = jest.fn(() =>

--- a/__test__/fixtures/game.ts
+++ b/__test__/fixtures/game.ts
@@ -1,5 +1,10 @@
 import { jest } from "@jest/globals";
-import { ApiResponse, Game, SetupInformation } from "@fc/types/types";
+import {
+    ApiResponse,
+    FrozenTurn,
+    Game,
+    SetupInformation,
+} from "@fc/types/types";
 import GameRepository from "@fc/server/repository/game";
 import { isLeft } from "fp-ts/Either";
 import { MakeRight } from "@fc/lib/io-ts-helpers";
@@ -31,9 +36,13 @@ export const setupInformation: SetupInformation = {
     phases,
 };
 
+/**
+ * The persisted snapshot shape - what a paused game stores as `frozenTurn`. It
+ * deliberately has no `lastUpdated`; that lives on the game document.
+ */
 export function makeFrozenTurn(
-    overrides: Partial<ApiResponse> = {},
-): ApiResponse {
+    overrides: Partial<FrozenTurn> = {},
+): FrozenTurn {
     return {
         turnNumber: 1,
         phase: 1,
@@ -43,6 +52,18 @@ export function makeFrozenTurn(
         components: [],
         ...overrides,
     };
+}
+
+/**
+ * The wire shape - a frozen turn plus the game-level `lastUpdated` stamp. Use
+ * this for asserting on route/`toApiResponse` bodies so that adding another
+ * document-level field later is a one-line change here rather than an edit to
+ * every assertion.
+ */
+export function makeApiResponse(
+    overrides: Partial<ApiResponse> = {},
+): ApiResponse {
+    return { ...makeFrozenTurn(), lastUpdated: 0, ...overrides };
 }
 
 export function makeActiveGame(overrides: Partial<Game> = {}): Game {

--- a/__test__/server/turn/toApiResponse.test.ts
+++ b/__test__/server/turn/toApiResponse.test.ts
@@ -6,9 +6,14 @@ import {
     jest,
     test,
 } from "@jest/globals";
-import { ApiResponse, Game, SetupInformation } from "@fc/types/types";
+import {
+    ApiResponse,
+    FrozenTurn,
+    Game,
+    SetupInformation,
+} from "@fc/types/types";
 import { setupInformation } from "./helpers";
-import { toApiResponse } from "@fc/server/turn";
+import { toApiResponse, toFrozenTurn } from "@fc/server/turn";
 
 describe("toApiResponse", () => {
     const mockedDate = new Date(2023, 1, 2, 3, 4, 5, 0);
@@ -68,6 +73,7 @@ describe("toApiResponse", () => {
             phase: 1,
             phaseEnd: 5,
             turnNumber: 1,
+            lastUpdated: 0,
         };
 
         expect(toApiResponse(baseGame)).toEqual(expected);
@@ -84,6 +90,7 @@ describe("toApiResponse", () => {
                 phase: 1,
                 phaseEnd: seconds,
                 turnNumber: 1,
+                lastUpdated: 0,
             };
 
             expect(toApiResponse(baseGame)).toEqual(expected);
@@ -101,6 +108,7 @@ describe("toApiResponse", () => {
                 phase: 1,
                 phaseEnd: 0,
                 turnNumber: 1,
+                lastUpdated: 0,
             };
 
             expect(toApiResponse(baseGame)).toEqual(expected);
@@ -146,13 +154,14 @@ describe("toApiResponse", () => {
             phase: 1,
             phaseEnd: 5,
             turnNumber: 1,
+            lastUpdated: 0,
         };
 
         expect(toApiResponse(game)).toEqual(expected);
     });
 
     test("Inactive turns returns the frozen turn", () => {
-        const frozenTurn: ApiResponse = {
+        const frozenTurn: FrozenTurn = {
             active: false,
             breakingNews: [],
             components: [],
@@ -167,11 +176,14 @@ describe("toApiResponse", () => {
             frozenTurn,
         };
 
-        expect(toApiResponse(game)).toEqual(frozenTurn);
+        expect(toApiResponse(game)).toEqual({
+            ...frozenTurn,
+            lastUpdated: 0,
+        });
     });
 
     test("Can force a refresh of an inactive turn", () => {
-        const frozenTurn: ApiResponse = {
+        const frozenTurn: FrozenTurn = {
             active: false,
             breakingNews: [],
             components: [],
@@ -208,8 +220,115 @@ describe("toApiResponse", () => {
             phase: 1,
             phaseEnd: 5,
             turnNumber: 1,
+            lastUpdated: 0,
         };
 
         expect(toApiResponse(game, true)).toEqual(expected);
+    });
+
+    describe("lastUpdated", () => {
+        test("reports 0 for a game with no stamp", () => {
+            // Games written before editing existed have no `lastUpdated` at all.
+            // They must report a constant, and it must be lower than any real
+            // stamp: a game reporting "now" would always look newer than the
+            // stamp a client rendered with, so every device would reload forever.
+            expect(baseGame.lastUpdated).toBeUndefined();
+            expect(toApiResponse(baseGame).lastUpdated).toBe(0);
+        });
+
+        test("reports the game's stamp for an active game", () => {
+            const game: Game = { ...baseGame, lastUpdated: 1700000000000 };
+
+            expect(toApiResponse(game).lastUpdated).toBe(1700000000000);
+        });
+
+        test("overlays the game's stamp onto a paused game's stored snapshot", () => {
+            // The load-bearing case. A paused game serves `frozenTurn` verbatim,
+            // and that snapshot was written *before* the edit that changed the
+            // game - so the stamp has to come from the document, or an edit
+            // would be invisible to every paused screen.
+            const game: Game = {
+                ...baseGame,
+                active: false,
+                frozenTurn: {
+                    active: false,
+                    breakingNews: [],
+                    components: [],
+                    phase: 2,
+                    phaseEnd: 42,
+                    turnNumber: 3,
+                },
+                lastUpdated: 1700000000000,
+            };
+
+            expect(toApiResponse(game)).toEqual({
+                active: false,
+                breakingNews: [],
+                components: [],
+                phase: 2,
+                phaseEnd: 42,
+                turnNumber: 3,
+                lastUpdated: 1700000000000,
+            });
+        });
+    });
+});
+
+describe("toFrozenTurn", () => {
+    // toFrozenTurn is what gets *persisted*, so it must never carry the
+    // document-level stamp - otherwise the stored copy could drift from the
+    // document and a paused game would serve a stale one.
+    const phaseEnd = new Date(2023, 1, 2, 3, 4, 10, 0);
+
+    const baseGame: Game = {
+        _id: "test",
+        setupInformation,
+        components: [],
+        active: true,
+        breakingNews: [],
+        turnInformation: {
+            turnNumber: 1,
+            currentPhase: 1,
+            phaseEnd: phaseEnd.toString(),
+        },
+        lastUpdated: 1700000000000,
+    };
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date(2023, 1, 2, 3, 4, 5, 0));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    test("omits lastUpdated even when the game has one", () => {
+        const frozen = toFrozenTurn(baseGame);
+
+        expect(Object.hasOwn(frozen, "lastUpdated")).toBe(false);
+        expect(frozen).toEqual({
+            active: true,
+            breakingNews: [],
+            components: [],
+            phase: 1,
+            phaseEnd: 5,
+            turnNumber: 1,
+        });
+    });
+
+    test("returns the stored snapshot verbatim for a paused game", () => {
+        const frozenTurn: FrozenTurn = {
+            active: false,
+            breakingNews: [],
+            components: [],
+            phase: 0,
+            phaseEnd: 0,
+            turnNumber: 0,
+        };
+
+        const game: Game = { ...baseGame, active: false, frozenTurn };
+
+        expect(toFrozenTurn(game)).toBe(frozenTurn);
     });
 });

--- a/src/server/turn.ts
+++ b/src/server/turn.ts
@@ -2,6 +2,7 @@ import {
     ApiResponse,
     ControlAction,
     ControlAPI,
+    FrozenTurn,
     Game,
     SetupInformation,
 } from "@fc/types/types";
@@ -48,10 +49,19 @@ export function nextDate(
     return MakeRight(date);
 }
 
-export function toApiResponse(
+/**
+ * The renderable state of a game: what a paused game has frozen, or what an
+ * active game looks like right now.
+ *
+ * This is the shape that gets *persisted* as `frozenTurn`, so it deliberately
+ * excludes anything that is a property of the game document rather than of the
+ * snapshot. Use it when building a snapshot to store; use
+ * {@link toApiResponse} when answering a client.
+ */
+export function toFrozenTurn(
     turn: Game,
     forceRefresh: boolean = false,
-): ApiResponse {
+): FrozenTurn {
     if (!turn.active && !forceRefresh) {
         return turn.frozenTurn;
     }
@@ -88,6 +98,36 @@ export function toApiResponse(
         turnNumber: turn.turnInformation.turnNumber,
         phase: turn.turnInformation.currentPhase,
         phaseEnd: secondsLeft,
+    };
+}
+
+/**
+ * Sentinel `lastUpdated` for a game written before editing existed. It must be a
+ * constant, not the current time: a game that reported "now" on every poll would
+ * always look newer than whatever stamp a client was rendered with, so every
+ * device would reload forever.
+ */
+const NEVER_EDITED = 0;
+
+/**
+ * The poll response for a game.
+ *
+ * `lastUpdated` is always read from the game document, never from the frozen
+ * snapshot. A paused game serves its stored snapshot verbatim, so a copy of the
+ * stamp inside that snapshot would be stale the moment the game was edited - and
+ * the whole point of the stamp is to tell open screens that it *was* edited.
+ *
+ * Only a structural edit bumps it. Turn ticks, control actions and press posts
+ * all flow through here too, and a stamp that moved on those would hard-reload
+ * every device in the venue at every phase boundary.
+ */
+export function toApiResponse(
+    turn: Game,
+    forceRefresh: boolean = false,
+): ApiResponse {
+    return {
+        ...toFrozenTurn(turn, forceRefresh),
+        lastUpdated: turn.lastUpdated ?? NEVER_EDITED,
     };
 }
 
@@ -227,7 +267,10 @@ export function createGame(
     return MakeRight({
         ...base,
         active: false,
-        frozenTurn: { ...toApiResponse(base), active: false },
+        // toFrozenTurn, not toApiResponse: the stamp is a property of the game
+        // document, so persisting a copy of it inside the snapshot would let the
+        // two drift.
+        frozenTurn: { ...toFrozenTurn(base), active: false },
     });
 }
 
@@ -253,8 +296,9 @@ export const CONTROL_ACTIONS: Record<ControlAPI["action"], ControlAction> = {
     pause: (game) => {
         return MakeRight({
             active: false,
-            frozenTurn: toApiResponse(
-                { ...game, active: false, frozenTurn: toApiResponse(game) },
+            // toFrozenTurn, not toApiResponse: see the comment in createGame.
+            frozenTurn: toFrozenTurn(
+                { ...game, active: false, frozenTurn: toFrozenTurn(game) },
                 true,
             ),
         });

--- a/src/types/io-ts-def.ts
+++ b/src/types/io-ts-def.ts
@@ -257,7 +257,16 @@ export const TurnInformationDecode = t.type({
     phaseEnd: t.string,
 });
 
-export const ApiResponseDecode = t.type({
+/**
+ * The rendered state of a game at a point in time.
+ *
+ * This is also the *persisted* shape of a paused game's `frozenTurn`, so it must
+ * contain only fields that are meaningful to freeze. Anything that is a property
+ * of the game document rather than of the snapshot belongs on
+ * {@link ApiResponseDecode} instead, or it would go stale the moment the game
+ * changed underneath a paused snapshot.
+ */
+export const FrozenTurnDecode = t.type({
     turnNumber: t.number,
     phase: t.number,
     breakingNews: t.array(NewsItemDecode),
@@ -265,6 +274,19 @@ export const ApiResponseDecode = t.type({
     phaseEnd: t.number,
     components: t.array(ComponentDecode),
 });
+
+/**
+ * The poll response: a frozen turn plus the game-document-level fields clients
+ * need. `lastUpdated` is always overlaid from the game by `toApiResponse`, never
+ * read out of a stored snapshot - see the docblock there.
+ */
+export const ApiResponseDecode = t.intersection([
+    FrozenTurnDecode,
+    t.type({
+        lastUpdated: t.number,
+    }),
+]);
+
 export const GameDecode = t.intersection([
     t.type({
         _id: t.string,
@@ -273,11 +295,25 @@ export const GameDecode = t.intersection([
         breakingNews: t.array(NewsItemDecode),
         components: t.array(ComponentDecode),
     }),
+    t.partial({
+        // Epoch milliseconds, bumped only when a game's *structure*
+        // (setupInformation / components) is edited - never by a turn tick, a
+        // control action or a press post. Clients compare it against the stamp
+        // their page was server-rendered from and hard-reload when it moves,
+        // which is the only way an edit reaches an already-open screen.
+        //
+        // Optional because stored games are cast rather than decoded (see
+        // `MongoRepository.get`), so making it required would be a type-level
+        // lie for every document written before editing existed. Readers go
+        // through `?? 0`; 0 is lower than any real stamp, so an unedited game
+        // never triggers a reload.
+        lastUpdated: t.number,
+    }),
     t.union([
         t.type({ active: t.literal(true) }),
         t.type({
             active: t.literal(false),
-            frozenTurn: ApiResponseDecode,
+            frozenTurn: FrozenTurnDecode,
         }),
     ]),
 ]);

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -3,6 +3,7 @@ import * as types from "./io-ts-def";
 import { Either } from "fp-ts/Either";
 
 export type ApiResponse = t.TypeOf<typeof types.ApiResponseDecode>;
+export type FrozenTurn = t.TypeOf<typeof types.FrozenTurnDecode>;
 export type NewsItem = t.TypeOf<typeof types.NewsItemDecode>;
 export type SetBreakingNews = t.TypeOf<typeof types.SetBreakingNewsDecode>;
 export type ControlAPI = t.TypeOf<typeof types.ControlAPIDecode>;


### PR DESCRIPTION
Closes #818. Second of seven phases in #816.

## Why

Open player, control and press screens receive the whole `Game` as a server-rendered prop and only ever poll `ApiResponse`, so phase titles, lengths, theme, press config and `maxTurns` never refresh. Clients need a way to notice that a game's *structure* changed. This adds the field they'll compare against.

**Nothing writes the stamp yet**, so every game reports the `0` sentinel and behaviour is unchanged. Deliberately inert groundwork.

## Split, not widened

`ApiResponseDecode` served two masters: the wire format **and** the persisted `frozenTurn` inside `GameDecode`. Because `toApiResponse` returns a paused game's stored snapshot verbatim, adding a required field to it would have made paused games serve a body that fails the client's own `ApiResponseDecode.is(body)` check — the client would discard every poll. So:

```
FrozenTurnDecode   - the renderable snapshot; what actually gets stored
ApiResponseDecode  - FrozenTurnDecode & { lastUpdated: number }
```

`toApiResponse` is now a thin wrapper over `toFrozenTurn` that overlays the stamp **from the game document**. That's the load-bearing decision: a paused game's snapshot was written *before* the edit that changed it, so a copy of the stamp inside the snapshot would be stale exactly when the stamp matters. `createGame` and `CONTROL_ACTIONS.pause` now build snapshots with `toFrozenTurn`, so the stamp is never persisted in two places and can't drift.

Keeping the stored shape byte-identical also kept four existing suites green that assert stored frozen turns exactly (`create-game`, `createGame`, `controlActions`, `hasFinished`). Widening `ApiResponseDecode` in place would have churned those too.

## Field choices

`lastUpdated` is **epoch milliseconds, optional on the game, required on the wire**.

- **Optional on the game** because stored games are cast rather than decoded (`MongoRepository.get` uses `games.find<Game>`), so requiring it would be a type-level lie for every document written before editing existed — the exact hazard `toGameSummary`'s docblock warns about. Readers go through `?? 0`. It also keeps `e2e/seed.ts`'s `Game` literals compiling untouched.
- **A number, not an ISO string**, because this codebase's other date fields use `Date.toString()` (`nextDate`, `generateNewTurnInformation`, `CONTROL_ACTIONS.play`, `e2e/seed.ts`), which produces `"Sun Jul 26 2026 12:00:00 GMT+0100"` and does *not* sort lexicographically. A number sidesteps anyone reasonably copying the local idiom.
- **The sentinel is the constant `0`, never `Date.now()`.** A legacy game reporting "now" on every poll would always look newer than the stamp its clients rendered with, reloading every device forever.

## The invariant

This is the real risk in #816, so it's worth stating plainly: **only a structural edit may bump the stamp.**

`toApiResponse` sits on every mutating path — the poll route via `nextTurn`, every control action, all seven component routes via `makeComponentRoute`, and the press route. A stamp that moved on any of those would turn "edit a live game" into "hard-reload every device in the venue at every phase boundary, forever".

There are currently **zero write sites** (`grep lastUpdated src/` shows one read in `turn.ts` and the two codec declarations), and the read behaviour is pinned by tests.

## Tests

- `__test__/fixtures/game.ts` — `makeFrozenTurn` keeps returning the unchanged snapshot shape; new `makeApiResponse` returns `{...makeFrozenTurn(), lastUpdated: 0}` so wire-body assertions have one place to change if another document-level field lands later.
- `toApiResponse.test.ts` — the existing bodies gain `lastUpdated: 0`; the two `frozenTurn` literals become `FrozenTurn`. New cases: reports `0` for a game with no stamp, reports the game's stamp for an active game, and **overlays the game's stamp onto a paused game's stored snapshot** (the case the split exists for). Plus a `toFrozenTurn` block asserting it omits `lastUpdated` even when the game has one, and returns the stored snapshot by reference.
- Wire-body `toEqual` assertions updated in `app/game/api.test.ts` (5), `app/game/control/api.test.ts` (14), `app/game/press.test.ts` (1), and `components/GameWrapper.test.tsx` (1 — that one matters, because `finishedBody` must satisfy `ApiResponseDecode.is` or the poll result is silently discarded and the test would pass for the wrong reason).

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npx tsc --noEmit -p e2e/tsconfig.json` — clean
- `npm test` — 43 suites / 679 tests passing (674 before, +5 new)
- `npx prettier --check` — clean

`GET /game/[id]/api` now returns `lastUpdated: 0` for every existing game, paused and active. No other observable change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9)_