### PR TITLE
feat(admin): add a shared structural editor for game components

### DIFF
--- a/__test__/components/ComponentsEditor.test.tsx
+++ b/__test__/components/ComponentsEditor.test.tsx
@@ -1,0 +1,563 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { fireEvent, render, screen } from "@testing-library/react";
+import * as t from "io-ts";
+import {
+    COMPONENT_LABELS,
+    COMPONENT_TYPES,
+    ComponentsEditor,
+    defaultComponent,
+    newKeyError,
+} from "@fc/components/admin/ComponentsEditor";
+import { ComponentDecode } from "@fc/types/io-ts-def";
+import { Component, ComponentType } from "@fc/types/types";
+
+type OnChange = (components: Component[]) => void;
+
+/** Render the editor and hand back the latest value it emitted. */
+function renderEditor(components: Component[]) {
+    const onChange = jest.fn<OnChange>();
+
+    const { rerender } = render(
+        <ComponentsEditor components={components} onChange={onChange} />,
+    );
+
+    return {
+        onChange,
+        rerender: (next: Component[]) =>
+            rerender(
+                <ComponentsEditor components={next} onChange={onChange} />,
+            ),
+        // The component is controlled, so a change is only ever reported - it is
+        // the caller's job to feed it back. Grab the single emitted value.
+        emitted: () => {
+            expect(onChange).toHaveBeenCalledTimes(1);
+            return onChange.mock.calls[0][0];
+        },
+    };
+}
+
+describe("defaultComponent", () => {
+    test.each(COMPONENT_TYPES)("produces a decodable %s", (type) => {
+        const component = defaultComponent(type);
+
+        expect(component.componentType).toBe(type);
+        // The server validates with this codec, so a default the editor can
+        // produce but the API would reject is a broken editor.
+        expect(ComponentDecode.is(component)).toBe(true);
+    });
+
+    test("covers every component type", () => {
+        // COMPONENT_TYPES is derived from COMPONENT_LABELS, which is a
+        // Record<ComponentType, string>, so TypeScript already forces the labels
+        // to stay in step with the union. This pins the count so a hand-edit
+        // that drops an entry is caught too.
+        expect(COMPONENT_TYPES).toHaveLength(7);
+        expect(Object.keys(COMPONENT_LABELS).sort()).toEqual(
+            [...COMPONENT_TYPES].sort(),
+        );
+    });
+});
+
+describe("newKeyError", () => {
+    test("allows an unused, safe name", () => {
+        expect(newKeyError("Bar", {}, "tracker")).toBeNull();
+    });
+
+    test("says nothing for an empty name", () => {
+        // Nothing typed yet - the Add button is disabled, so there is nothing to
+        // complain about.
+        expect(newKeyError("", {}, "tracker")).toBeNull();
+    });
+
+    test.each(["__proto__", "constructor", "prototype"])(
+        "rejects the prototype-polluting name %p",
+        (key) => {
+            expect(newKeyError(key, {}, "tracker")).toBe(
+                `"${key}" is not an allowed tracker name`,
+            );
+        },
+    );
+
+    test("rejects a name that is already used", () => {
+        expect(newKeyError("Bar", { Bar: 1 }, "tracker")).toBe(
+            'There is already a tracker called "Bar"',
+        );
+    });
+
+    test("does not treat an inherited member as already used", () => {
+        // `"toString" in {}` is true, so an `in` check would refuse a perfectly
+        // usable name. Object.hasOwn is the right test.
+        expect(newKeyError("toString", {}, "tracker")).toBeNull();
+    });
+});
+
+describe("ComponentsEditor", () => {
+    test("tells the operator when there are no components", () => {
+        renderEditor([]);
+
+        expect(
+            screen.getByText(
+                "This game has no components. Add one below if you need any.",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    test("renders a card per component, labelled", () => {
+        renderEditor([
+            defaultComponent("Weather"),
+            defaultComponent("Trackers"),
+        ]);
+
+        expect(
+            screen.getByRole("heading", { name: "Weather message" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("heading", { name: "Trackers" }),
+        ).toBeInTheDocument();
+    });
+
+    test("adds the selected component type", () => {
+        const { onChange, emitted } = renderEditor([]);
+
+        fireEvent.change(screen.getByLabelText("Component type"), {
+            target: { value: "LightLevel" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Add component" }));
+
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(emitted()).toEqual([defaultComponent("LightLevel")]);
+    });
+
+    test("removes a component", () => {
+        const { emitted } = renderEditor([
+            defaultComponent("Weather"),
+            defaultComponent("LightLevel"),
+        ]);
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "Remove Weather message" }),
+        );
+
+        expect(emitted()).toEqual([defaultComponent("LightLevel")]);
+    });
+
+    describe("the add dropdown", () => {
+        test("omits types the game already has", () => {
+            renderEditor([defaultComponent("Weather")]);
+
+            const options = screen
+                .getAllByRole("option")
+                .map((option) => (option as HTMLOptionElement).value);
+
+            // One of each type only: `findComponent` server-side takes the first
+            // match, so a second Weather would be unreachable from the control
+            // desk.
+            expect(options).not.toContain("Weather");
+            expect(options).toContain("LightLevel");
+            expect(options).toHaveLength(COMPONENT_TYPES.length - 1);
+        });
+
+        test("disappears once every type is present", () => {
+            renderEditor(COMPONENT_TYPES.map(defaultComponent));
+
+            expect(
+                screen.queryByRole("button", { name: "Add component" }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByText(
+                    "Every component type is already on this game.",
+                ),
+            ).toBeInTheDocument();
+        });
+
+        test("falls back to an available type when the selected one is taken", () => {
+            // Defcon is the initial selection. Adding it should not leave the
+            // dropdown pointing at a type that is no longer offered.
+            const { rerender } = renderEditor([]);
+
+            fireEvent.click(
+                screen.getByRole("button", { name: "Add component" }),
+            );
+
+            rerender([defaultComponent("Defcon")]);
+
+            const select = screen.getByLabelText(
+                "Component type",
+            ) as HTMLSelectElement;
+
+            expect(select.value).not.toBe("Defcon");
+            expect(COMPONENT_TYPES).toContain(select.value as ComponentType);
+        });
+    });
+
+    describe("Defcon", () => {
+        const withCountry: Component = {
+            componentType: "Defcon",
+            countries: {
+                China: {
+                    shortName: "CN",
+                    countryName: "China",
+                    status: 3,
+                },
+            },
+        };
+
+        test("edits a country's fields", () => {
+            const { emitted } = renderEditor([withCountry]);
+
+            fireEvent.change(screen.getByLabelText("China country name"), {
+                target: { value: "People's Republic" },
+            });
+
+            expect(emitted()).toEqual([
+                {
+                    componentType: "Defcon",
+                    countries: {
+                        China: {
+                            shortName: "CN",
+                            countryName: "People's Republic",
+                            status: 3,
+                        },
+                    },
+                },
+            ]);
+        });
+
+        test("edits a country's status, keeping hidden a string", () => {
+            const { emitted } = renderEditor([withCountry]);
+
+            fireEvent.change(screen.getByLabelText("China defcon status"), {
+                target: { value: "hidden" },
+            });
+
+            const [component] = emitted();
+            expect(component).toEqual({
+                componentType: "Defcon",
+                countries: {
+                    China: {
+                        shortName: "CN",
+                        countryName: "China",
+                        status: "hidden",
+                    },
+                },
+            });
+            expect(ComponentDecode.is(component)).toBe(true);
+        });
+
+        test("adds a country", () => {
+            const { emitted } = renderEditor([defaultComponent("Defcon")]);
+
+            fireEvent.change(screen.getByLabelText("New country name"), {
+                target: { value: "France" },
+            });
+            fireEvent.click(
+                screen.getByRole("button", { name: "Add country" }),
+            );
+
+            expect(emitted()).toEqual([
+                {
+                    componentType: "Defcon",
+                    countries: {
+                        France: {
+                            shortName: "",
+                            countryName: "France",
+                            status: 3,
+                        },
+                    },
+                },
+            ]);
+        });
+
+        test("removes a country", () => {
+            const { emitted } = renderEditor([withCountry]);
+
+            fireEvent.click(
+                screen.getByRole("button", { name: "Remove China" }),
+            );
+
+            expect(emitted()).toEqual([
+                { componentType: "Defcon", countries: {} },
+            ]);
+        });
+
+        test("refuses a prototype-polluting country name", () => {
+            const { onChange } = renderEditor([defaultComponent("Defcon")]);
+
+            fireEvent.change(screen.getByLabelText("New country name"), {
+                target: { value: "__proto__" },
+            });
+
+            expect(screen.getByRole("alert")).toHaveTextContent(
+                '"__proto__" is not an allowed country name',
+            );
+            expect(
+                screen.getByRole("button", { name: "Add country" }),
+            ).toBeDisabled();
+
+            fireEvent.click(
+                screen.getByRole("button", { name: "Add country" }),
+            );
+            expect(onChange).not.toHaveBeenCalled();
+        });
+
+        test("refuses a duplicate country name", () => {
+            const { onChange } = renderEditor([withCountry]);
+
+            fireEvent.change(screen.getByLabelText("New country name"), {
+                target: { value: "China" },
+            });
+
+            expect(screen.getByRole("alert")).toHaveTextContent(
+                'There is already a country called "China"',
+            );
+            expect(onChange).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("Trackers", () => {
+        const withTracker: Component = {
+            componentType: "Trackers",
+            trackers: { Bar: { value: 2, type: "bar", max: 10 } },
+        };
+
+        test("adds a tracker with sane defaults", () => {
+            const { emitted } = renderEditor([defaultComponent("Trackers")]);
+
+            fireEvent.change(screen.getByLabelText("New tracker name"), {
+                target: { value: "Tension" },
+            });
+            fireEvent.click(
+                screen.getByRole("button", { name: "Add tracker" }),
+            );
+
+            expect(emitted()).toEqual([
+                {
+                    componentType: "Trackers",
+                    trackers: { Tension: { value: 0, type: "bar", max: 10 } },
+                },
+            ]);
+        });
+
+        test("changes a tracker's maximum", () => {
+            const { emitted } = renderEditor([withTracker]);
+
+            fireEvent.change(screen.getByLabelText("Bar maximum"), {
+                target: { value: "35" },
+            });
+
+            expect(emitted()).toEqual([
+                {
+                    componentType: "Trackers",
+                    trackers: { Bar: { value: 2, type: "bar", max: 35 } },
+                },
+            ]);
+        });
+
+        test("changes a tracker's style", () => {
+            const { emitted } = renderEditor([withTracker]);
+
+            fireEvent.change(screen.getByLabelText("Bar style"), {
+                target: { value: "circle" },
+            });
+
+            expect(emitted()).toEqual([
+                {
+                    componentType: "Trackers",
+                    trackers: { Bar: { value: 2, type: "circle", max: 10 } },
+                },
+            ]);
+        });
+
+        test("coerces a non-numeric value to 0 rather than NaN", () => {
+            const { emitted } = renderEditor([withTracker]);
+
+            fireEvent.change(screen.getByLabelText("Bar value"), {
+                target: { value: "banana" },
+            });
+
+            const [component] = emitted();
+            expect(component).toEqual({
+                componentType: "Trackers",
+                trackers: { Bar: { value: 0, type: "bar", max: 10 } },
+            });
+            expect(ComponentDecode.is(component)).toBe(true);
+        });
+
+        test("removes a tracker", () => {
+            const { emitted } = renderEditor([withTracker]);
+
+            fireEvent.click(screen.getByRole("button", { name: "Remove Bar" }));
+
+            expect(emitted()).toEqual([
+                { componentType: "Trackers", trackers: {} },
+            ]);
+        });
+
+        test("refuses an unsafe tracker name", () => {
+            const { onChange } = renderEditor([defaultComponent("Trackers")]);
+
+            fireEvent.change(screen.getByLabelText("New tracker name"), {
+                target: { value: "constructor" },
+            });
+
+            expect(screen.getByRole("alert")).toHaveTextContent(
+                '"constructor" is not an allowed tracker name',
+            );
+            expect(onChange).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("RunningHotRunners", () => {
+        const withRunner: Component = {
+            componentType: "RunningHotRunners",
+            rep: { Ace: { reputation: 3, gang: "Dancers" } },
+        };
+
+        test("adds a runner with the chosen gang", () => {
+            const { emitted } = renderEditor([
+                defaultComponent("RunningHotRunners"),
+            ]);
+
+            fireEvent.change(screen.getByLabelText("New runner name"), {
+                target: { value: "Nyx" },
+            });
+            fireEvent.change(screen.getByLabelText("Gang"), {
+                target: { value: "Facers" },
+            });
+            fireEvent.click(screen.getByRole("button", { name: "Add runner" }));
+
+            expect(emitted()).toEqual([
+                {
+                    componentType: "RunningHotRunners",
+                    rep: { Nyx: { reputation: 1, gang: "Facers" } },
+                },
+            ]);
+        });
+
+        test("changes a runner's gang", () => {
+            const { emitted } = renderEditor([withRunner]);
+
+            fireEvent.change(screen.getByLabelText("Ace gang"), {
+                target: { value: "G33ks" },
+            });
+
+            expect(emitted()).toEqual([
+                {
+                    componentType: "RunningHotRunners",
+                    rep: { Ace: { reputation: 3, gang: "G33ks" } },
+                },
+            ]);
+        });
+
+        test("removes a runner", () => {
+            const { emitted } = renderEditor([withRunner]);
+
+            fireEvent.click(screen.getByRole("button", { name: "Remove Ace" }));
+
+            expect(emitted()).toEqual([
+                { componentType: "RunningHotRunners", rep: {} },
+            ]);
+        });
+    });
+
+    describe("Weather, LightLevel and RunningHotCorp", () => {
+        test("edits the weather message", () => {
+            const { emitted } = renderEditor([defaultComponent("Weather")]);
+
+            fireEvent.change(screen.getByLabelText("Weather message"), {
+                target: { value: "Storms inbound" },
+            });
+
+            expect(emitted()).toEqual([
+                { componentType: "Weather", weatherMessage: "Storms inbound" },
+            ]);
+        });
+
+        test("edits the light level maximum", () => {
+            const { emitted } = renderEditor([defaultComponent("LightLevel")]);
+
+            fireEvent.change(screen.getByLabelText("Maximum"), {
+                target: { value: "20" },
+            });
+
+            expect(emitted()).toEqual([
+                { componentType: "LightLevel", value: 10, max: 20 },
+            ]);
+        });
+
+        test("edits a corp's share price", () => {
+            const { emitted } = renderEditor([
+                defaultComponent("RunningHotCorp"),
+            ]);
+
+            fireEvent.change(screen.getByLabelText("GenEq"), {
+                target: { value: "42" },
+            });
+
+            const [component] = emitted();
+            expect(component).toMatchObject({
+                componentType: "RunningHotCorp",
+                sharePrice: { GenEq: 42, MCM: 10 },
+            });
+            expect(ComponentDecode.is(component)).toBe(true);
+        });
+    });
+
+    describe("the wolf attack alert", () => {
+        test("toggles the attack flag", () => {
+            const { emitted } = renderEditor([
+                defaultComponent("DoWWolfAttack"),
+            ]);
+
+            fireEvent.click(screen.getByLabelText("Attack in progress"));
+
+            expect(emitted()).toEqual([
+                { componentType: "DoWWolfAttack", inProgress: true },
+            ]);
+        });
+
+        test("adding a custom alert produces a decodable component", () => {
+            const { emitted } = renderEditor([
+                defaultComponent("DoWWolfAttack"),
+            ]);
+
+            fireEvent.click(screen.getByLabelText("Customise the alert text"));
+
+            const [component] = emitted();
+            expect(component).toMatchObject({
+                componentType: "DoWWolfAttack",
+                alert: { label: "Wolf attack" },
+            });
+            expect(ComponentDecode.is(component)).toBe(true);
+        });
+
+        test("clearing the custom alert drops the key rather than nulling it", () => {
+            // `alert` is optional in the codec. Setting it to undefined would be
+            // persisted as a null by Mongo and fail to decode on the way back.
+            const { emitted } = renderEditor([
+                {
+                    componentType: "DoWWolfAttack",
+                    inProgress: true,
+                    alert: { text: "t", label: "l", emoji: "🐺" },
+                },
+            ]);
+
+            fireEvent.click(screen.getByLabelText("Customise the alert text"));
+
+            const [component] = emitted();
+            expect(Object.hasOwn(component, "alert")).toBe(false);
+            expect(component).toEqual({
+                componentType: "DoWWolfAttack",
+                inProgress: true,
+            });
+        });
+    });
+
+    test("every emitted component list stays decodable", () => {
+        // A broad backstop: whatever the editor hands back must satisfy the codec
+        // the edit API validates with, or the operator gets an opaque 400.
+        const all = COMPONENT_TYPES.map(defaultComponent);
+
+        expect(t.array(ComponentDecode).is(all)).toBe(true);
+    });
+});

--- a/src/components/admin/ComponentsEditor.tsx
+++ b/src/components/admin/ComponentsEditor.tsx
@@ -1,0 +1,876 @@
+"use client";
+
+import { useState } from "react";
+import {
+    Component,
+    ComponentType,
+    DefconStatus,
+    GangNames,
+} from "@fc/types/types";
+// Type-only import: `ComponentOfType` is the existing definition of "the
+// concrete variant for a discriminant", and duplicating it here would let the
+// two drift. `import type` is erased at compile time, so pulling it from a
+// server module cannot drag server code into the client bundle.
+import type { ComponentOfType } from "@fc/server/components";
+import { isUnsafeKey } from "@fc/lib/safe-keys";
+
+type EditorProps<T extends ComponentType> = {
+    component: ComponentOfType<T>;
+    onChange: (component: ComponentOfType<T>) => void;
+};
+
+export const COMPONENT_LABELS: Record<ComponentType, string> = {
+    Defcon: "Defcon statuses",
+    Weather: "Weather message",
+    DoWWolfAttack: "Wolf attack",
+    RunningHotCorp: "Running Hot: share prices",
+    RunningHotRunners: "Running Hot: runner reputation",
+    Trackers: "Trackers",
+    LightLevel: "Light level",
+};
+
+export const COMPONENT_TYPES = Object.keys(COMPONENT_LABELS) as ComponentType[];
+
+export function defaultComponent(type: ComponentType): Component {
+    switch (type) {
+        case "Defcon":
+            return { componentType: "Defcon", countries: {} };
+        case "Weather":
+            return { componentType: "Weather", weatherMessage: "" };
+        case "DoWWolfAttack":
+            return { componentType: "DoWWolfAttack", inProgress: false };
+        case "RunningHotCorp":
+            return {
+                componentType: "RunningHotCorp",
+                sharePrice: {
+                    GenEq: 10,
+                    MCM: 10,
+                    Gordon: 10,
+                    ANT: 10,
+                    DTC: 10,
+                },
+            };
+        case "RunningHotRunners":
+            return { componentType: "RunningHotRunners", rep: {} };
+        case "Trackers":
+            return { componentType: "Trackers", trackers: {} };
+        case "LightLevel":
+            return { componentType: "LightLevel", value: 10, max: 10 };
+    }
+}
+
+const INPUT_CLASSES =
+    "block w-full rounded-lg border-zinc-700 bg-zinc-950 text-zinc-100 placeholder-zinc-500 focus:border-indigo-500 focus:ring-indigo-500 text-sm";
+const FIELD_LABEL_CLASSES = "block text-xs font-medium text-zinc-400";
+const ADD_BUTTON_CLASSES =
+    "rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm font-medium text-zinc-200 transition hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50";
+const REMOVE_BUTTON_CLASSES =
+    "text-sm font-medium text-red-300 transition hover:text-red-200";
+const KEY_ERROR_CLASSES = "mt-1 text-xs text-red-300";
+
+function toNumber(value: string): number {
+    const parsed = Number(value);
+
+    return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * Why a new entry's name cannot be used, or null if it can.
+ *
+ * Defcon countries, runners and trackers are all `t.record(t.string, ...)`, so
+ * the operator names the key. Two things have to be caught before it becomes an
+ * object property:
+ *
+ *  - prototype-polluting names, via the same `isUnsafeKey` guard the tracker
+ *    control route applies server-side;
+ *  - names that already exist. `Object.hasOwn` rather than `in`, because `in`
+ *    also matches inherited members, so `"toString"` would read as a duplicate
+ *    of something that was never added (see the docblock on `isUnsafeKey`).
+ *
+ * An empty string returns null: nothing has been typed yet, so there is nothing
+ * to complain about - the Add button is simply disabled.
+ */
+export function newKeyError(
+    key: string,
+    existing: Record<string, unknown>,
+    label: string,
+): string | null {
+    if (key === "") {
+        return null;
+    }
+
+    if (isUnsafeKey(key)) {
+        return `"${key}" is not an allowed ${label} name`;
+    }
+
+    if (Object.hasOwn(existing, key)) {
+        return `There is already a ${label} called "${key}"`;
+    }
+
+    return null;
+}
+
+function DefconEditor({ component, onChange }: EditorProps<"Defcon">) {
+    const [newCountry, setNewCountry] = useState("");
+
+    const setCountries = (countries: ComponentOfType<"Defcon">["countries"]) =>
+        onChange({ ...component, countries });
+
+    const countryKey = newCountry.trim();
+    const error = newKeyError(countryKey, component.countries, "country");
+    const canAdd = countryKey !== "" && error === null;
+
+    return (
+        <div className="flex flex-col gap-3">
+            {Object.entries(component.countries).map(([key, country]) => (
+                <div
+                    key={key}
+                    className="grid grid-cols-[4rem_1fr_8rem_auto] items-end gap-2"
+                >
+                    <div>
+                        <label className={FIELD_LABEL_CLASSES}>Flag</label>
+                        <input
+                            aria-label={`${key} flag`}
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={country.shortName}
+                            onChange={(event) =>
+                                setCountries({
+                                    ...component.countries,
+                                    [key]: {
+                                        ...country,
+                                        shortName: event.target.value,
+                                    },
+                                })
+                            }
+                        />
+                    </div>
+                    <div>
+                        <label className={FIELD_LABEL_CLASSES}>Country</label>
+                        <input
+                            aria-label={`${key} country name`}
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={country.countryName}
+                            onChange={(event) =>
+                                setCountries({
+                                    ...component.countries,
+                                    [key]: {
+                                        ...country,
+                                        countryName: event.target.value,
+                                    },
+                                })
+                            }
+                        />
+                    </div>
+                    <div>
+                        <label className={FIELD_LABEL_CLASSES}>Status</label>
+                        <select
+                            aria-label={`${key} defcon status`}
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={`${country.status}`}
+                            onChange={(event) => {
+                                const status: DefconStatus =
+                                    event.target.value == "hidden"
+                                        ? "hidden"
+                                        : (toNumber(
+                                              event.target.value,
+                                          ) as DefconStatus);
+
+                                setCountries({
+                                    ...component.countries,
+                                    [key]: { ...country, status },
+                                });
+                            }}
+                        >
+                            <option value="hidden">Hidden</option>
+                            <option value="3">3</option>
+                            <option value="2">2</option>
+                            <option value="1">1</option>
+                        </select>
+                    </div>
+                    <button
+                        type="button"
+                        className={`pb-2 ${REMOVE_BUTTON_CLASSES}`}
+                        onClick={() => {
+                            const countries = { ...component.countries };
+                            delete countries[key];
+                            setCountries(countries);
+                        }}
+                    >
+                        Remove {key}
+                    </button>
+                </div>
+            ))}
+            <div>
+                <div className="flex items-end gap-2">
+                    <div className="grow">
+                        <label
+                            className={FIELD_LABEL_CLASSES}
+                            htmlFor="new-defcon-country"
+                        >
+                            New country name
+                        </label>
+                        <input
+                            id="new-defcon-country"
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={newCountry}
+                            onChange={(event) =>
+                                setNewCountry(event.target.value)
+                            }
+                        />
+                    </div>
+                    <button
+                        type="button"
+                        className={ADD_BUTTON_CLASSES}
+                        disabled={!canAdd}
+                        onClick={() => {
+                            setCountries({
+                                ...component.countries,
+                                [countryKey]: {
+                                    shortName: "",
+                                    countryName: countryKey,
+                                    status: 3,
+                                },
+                            });
+                            setNewCountry("");
+                        }}
+                    >
+                        Add country
+                    </button>
+                </div>
+                {error !== null ? (
+                    <p role="alert" className={KEY_ERROR_CLASSES}>
+                        {error}
+                    </p>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function WeatherEditor({ component, onChange }: EditorProps<"Weather">) {
+    return (
+        <div>
+            <label className={FIELD_LABEL_CLASSES} htmlFor="weather-message">
+                Weather message
+            </label>
+            <input
+                id="weather-message"
+                className={`mt-1 ${INPUT_CLASSES}`}
+                value={component.weatherMessage}
+                onChange={(event) =>
+                    onChange({
+                        ...component,
+                        weatherMessage: event.target.value,
+                    })
+                }
+            />
+        </div>
+    );
+}
+
+function WolfAttackEditor({
+    component,
+    onChange,
+}: EditorProps<"DoWWolfAttack">) {
+    return (
+        <div className="flex flex-col gap-3">
+            <label className="flex items-center gap-x-2 text-sm text-zinc-300">
+                <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-zinc-600 bg-zinc-900 text-indigo-600 focus:ring-indigo-500 focus:ring-offset-zinc-900"
+                    checked={component.inProgress}
+                    onChange={(event) =>
+                        onChange({
+                            ...component,
+                            inProgress: event.target.checked,
+                        })
+                    }
+                />
+                Attack in progress
+            </label>
+            <label className="flex items-center gap-x-2 text-sm text-zinc-300">
+                <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-zinc-600 bg-zinc-900 text-indigo-600 focus:ring-indigo-500 focus:ring-offset-zinc-900"
+                    checked={component.alert !== undefined}
+                    onChange={(event) => {
+                        if (event.target.checked) {
+                            onChange({
+                                ...component,
+                                alert: {
+                                    text: "Wolf attack in progress",
+                                    label: "Wolf attack",
+                                    emoji: "🐺",
+                                },
+                            });
+                        } else {
+                            // Rebuild without `alert` rather than setting it to
+                            // undefined: the field is optional in the codec, and
+                            // an explicit undefined would be persisted as a null.
+                            onChange({
+                                componentType: component.componentType,
+                                inProgress: component.inProgress,
+                            });
+                        }
+                    }}
+                />
+                Customise the alert text
+            </label>
+            {component.alert !== undefined ? (
+                <div className="grid gap-2 sm:grid-cols-3">
+                    {(["text", "label", "emoji"] as const).map((field) => (
+                        <div key={field}>
+                            <label
+                                className={`capitalize ${FIELD_LABEL_CLASSES}`}
+                                htmlFor={`wolf-alert-${field}`}
+                            >
+                                {field}
+                            </label>
+                            <input
+                                id={`wolf-alert-${field}`}
+                                className={`mt-1 ${INPUT_CLASSES}`}
+                                value={component.alert?.[field] ?? ""}
+                                onChange={(event) =>
+                                    onChange({
+                                        ...component,
+                                        alert: {
+                                            text: "",
+                                            label: "",
+                                            emoji: "",
+                                            ...component.alert,
+                                            [field]: event.target.value,
+                                        },
+                                    })
+                                }
+                            />
+                        </div>
+                    ))}
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+function RunningHotCorpEditor({
+    component,
+    onChange,
+}: EditorProps<"RunningHotCorp">) {
+    return (
+        <div className="grid gap-2 sm:grid-cols-5">
+            {Object.entries(component.sharePrice).map(([corp, price]) => (
+                <div key={corp}>
+                    <label
+                        className={FIELD_LABEL_CLASSES}
+                        htmlFor={`share-price-${corp}`}
+                    >
+                        {corp}
+                    </label>
+                    <input
+                        id={`share-price-${corp}`}
+                        type="number"
+                        className={`mt-1 ${INPUT_CLASSES}`}
+                        value={price}
+                        onChange={(event) =>
+                            onChange({
+                                ...component,
+                                sharePrice: {
+                                    ...component.sharePrice,
+                                    [corp]: toNumber(event.target.value),
+                                },
+                            })
+                        }
+                    />
+                </div>
+            ))}
+        </div>
+    );
+}
+
+const GANGS: GangNames[] = ["Dancers", "G33ks", "Facers", "Gruffsters"];
+
+function RunningHotRunnersEditor({
+    component,
+    onChange,
+}: EditorProps<"RunningHotRunners">) {
+    const [newRunner, setNewRunner] = useState("");
+    const [newGang, setNewGang] = useState<GangNames>("Dancers");
+
+    const setRep = (rep: ComponentOfType<"RunningHotRunners">["rep"]) =>
+        onChange({ ...component, rep });
+
+    const runnerKey = newRunner.trim();
+    const error = newKeyError(runnerKey, component.rep, "runner");
+    const canAdd = runnerKey !== "" && error === null;
+
+    return (
+        <div className="flex flex-col gap-3">
+            {Object.entries(component.rep).map(([runner, details]) => (
+                <div
+                    key={runner}
+                    className="grid grid-cols-[1fr_10rem_6rem_auto] items-end gap-2"
+                >
+                    <span className="pb-2 text-sm text-zinc-300">{runner}</span>
+                    <div>
+                        <label className={FIELD_LABEL_CLASSES}>Gang</label>
+                        <select
+                            aria-label={`${runner} gang`}
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={details.gang}
+                            onChange={(event) =>
+                                setRep({
+                                    ...component.rep,
+                                    [runner]: {
+                                        ...details,
+                                        gang: event.target.value as GangNames,
+                                    },
+                                })
+                            }
+                        >
+                            {GANGS.map((gang) => (
+                                <option key={gang} value={gang}>
+                                    {gang}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <div>
+                        <label className={FIELD_LABEL_CLASSES}>Rep</label>
+                        <input
+                            aria-label={`${runner} reputation`}
+                            type="number"
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={details.reputation}
+                            onChange={(event) =>
+                                setRep({
+                                    ...component.rep,
+                                    [runner]: {
+                                        ...details,
+                                        reputation: toNumber(
+                                            event.target.value,
+                                        ),
+                                    },
+                                })
+                            }
+                        />
+                    </div>
+                    <button
+                        type="button"
+                        className={`pb-2 ${REMOVE_BUTTON_CLASSES}`}
+                        onClick={() => {
+                            const rep = { ...component.rep };
+                            delete rep[runner];
+                            setRep(rep);
+                        }}
+                    >
+                        Remove {runner}
+                    </button>
+                </div>
+            ))}
+            <div>
+                <div className="flex items-end gap-2">
+                    <div className="grow">
+                        <label
+                            className={FIELD_LABEL_CLASSES}
+                            htmlFor="new-runner-name"
+                        >
+                            New runner name
+                        </label>
+                        <input
+                            id="new-runner-name"
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={newRunner}
+                            onChange={(event) =>
+                                setNewRunner(event.target.value)
+                            }
+                        />
+                    </div>
+                    <div>
+                        <label
+                            className={FIELD_LABEL_CLASSES}
+                            htmlFor="new-runner-gang"
+                        >
+                            Gang
+                        </label>
+                        <select
+                            id="new-runner-gang"
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={newGang}
+                            onChange={(event) =>
+                                setNewGang(event.target.value as GangNames)
+                            }
+                        >
+                            {GANGS.map((gang) => (
+                                <option key={gang} value={gang}>
+                                    {gang}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <button
+                        type="button"
+                        className={ADD_BUTTON_CLASSES}
+                        disabled={!canAdd}
+                        onClick={() => {
+                            setRep({
+                                ...component.rep,
+                                [runnerKey]: { gang: newGang, reputation: 1 },
+                            });
+                            setNewRunner("");
+                        }}
+                    >
+                        Add runner
+                    </button>
+                </div>
+                {error !== null ? (
+                    <p role="alert" className={KEY_ERROR_CLASSES}>
+                        {error}
+                    </p>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function TrackersEditor({ component, onChange }: EditorProps<"Trackers">) {
+    const [newTracker, setNewTracker] = useState("");
+
+    const setTrackers = (trackers: ComponentOfType<"Trackers">["trackers"]) =>
+        onChange({ ...component, trackers });
+
+    const trackerKey = newTracker.trim();
+    const error = newKeyError(trackerKey, component.trackers, "tracker");
+    const canAdd = trackerKey !== "" && error === null;
+
+    return (
+        <div className="flex flex-col gap-3">
+            {Object.entries(component.trackers).map(([name, tracker]) => (
+                <div
+                    key={name}
+                    className="grid grid-cols-[1fr_8rem_6rem_6rem_auto] items-end gap-2"
+                >
+                    <span className="pb-2 text-sm text-zinc-300">{name}</span>
+                    <div>
+                        <label className={FIELD_LABEL_CLASSES}>Style</label>
+                        <select
+                            aria-label={`${name} style`}
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={tracker.type}
+                            onChange={(event) =>
+                                setTrackers({
+                                    ...component.trackers,
+                                    [name]: {
+                                        ...tracker,
+                                        type:
+                                            event.target.value == "circle"
+                                                ? "circle"
+                                                : "bar",
+                                    },
+                                })
+                            }
+                        >
+                            <option value="bar">Bar</option>
+                            <option value="circle">Circle</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label className={FIELD_LABEL_CLASSES}>Value</label>
+                        <input
+                            aria-label={`${name} value`}
+                            type="number"
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={tracker.value}
+                            onChange={(event) =>
+                                setTrackers({
+                                    ...component.trackers,
+                                    [name]: {
+                                        ...tracker,
+                                        value: toNumber(event.target.value),
+                                    },
+                                })
+                            }
+                        />
+                    </div>
+                    <div>
+                        <label className={FIELD_LABEL_CLASSES}>Max</label>
+                        <input
+                            aria-label={`${name} maximum`}
+                            type="number"
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={tracker.max}
+                            onChange={(event) =>
+                                setTrackers({
+                                    ...component.trackers,
+                                    [name]: {
+                                        ...tracker,
+                                        max: toNumber(event.target.value),
+                                    },
+                                })
+                            }
+                        />
+                    </div>
+                    <button
+                        type="button"
+                        className={`pb-2 ${REMOVE_BUTTON_CLASSES}`}
+                        onClick={() => {
+                            const trackers = { ...component.trackers };
+                            delete trackers[name];
+                            setTrackers(trackers);
+                        }}
+                    >
+                        Remove {name}
+                    </button>
+                </div>
+            ))}
+            <div>
+                <div className="flex items-end gap-2">
+                    <div className="grow">
+                        <label
+                            className={FIELD_LABEL_CLASSES}
+                            htmlFor="new-tracker-name"
+                        >
+                            New tracker name
+                        </label>
+                        <input
+                            id="new-tracker-name"
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={newTracker}
+                            onChange={(event) =>
+                                setNewTracker(event.target.value)
+                            }
+                        />
+                    </div>
+                    <button
+                        type="button"
+                        className={ADD_BUTTON_CLASSES}
+                        disabled={!canAdd}
+                        onClick={() => {
+                            setTrackers({
+                                ...component.trackers,
+                                [trackerKey]: {
+                                    value: 0,
+                                    type: "bar",
+                                    max: 10,
+                                },
+                            });
+                            setNewTracker("");
+                        }}
+                    >
+                        Add tracker
+                    </button>
+                </div>
+                {error !== null ? (
+                    <p role="alert" className={KEY_ERROR_CLASSES}>
+                        {error}
+                    </p>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function LightLevelEditor({ component, onChange }: EditorProps<"LightLevel">) {
+    return (
+        <div className="grid gap-2 sm:grid-cols-2">
+            <div>
+                <label
+                    className={FIELD_LABEL_CLASSES}
+                    htmlFor="light-level-value"
+                >
+                    Value
+                </label>
+                <input
+                    id="light-level-value"
+                    type="number"
+                    className={`mt-1 ${INPUT_CLASSES}`}
+                    value={component.value}
+                    onChange={(event) =>
+                        onChange({
+                            ...component,
+                            value: toNumber(event.target.value),
+                        })
+                    }
+                />
+            </div>
+            <div>
+                <label
+                    className={FIELD_LABEL_CLASSES}
+                    htmlFor="light-level-max"
+                >
+                    Maximum
+                </label>
+                <input
+                    id="light-level-max"
+                    type="number"
+                    className={`mt-1 ${INPUT_CLASSES}`}
+                    value={component.max}
+                    onChange={(event) =>
+                        onChange({
+                            ...component,
+                            max: toNumber(event.target.value),
+                        })
+                    }
+                />
+            </div>
+        </div>
+    );
+}
+
+function ComponentEditor({
+    component,
+    onChange,
+}: {
+    component: Component;
+    onChange: (component: Component) => void;
+}) {
+    switch (component.componentType) {
+        case "Defcon":
+            return <DefconEditor component={component} onChange={onChange} />;
+        case "Weather":
+            return <WeatherEditor component={component} onChange={onChange} />;
+        case "DoWWolfAttack":
+            return (
+                <WolfAttackEditor component={component} onChange={onChange} />
+            );
+        case "RunningHotCorp":
+            return (
+                <RunningHotCorpEditor
+                    component={component}
+                    onChange={onChange}
+                />
+            );
+        case "RunningHotRunners":
+            return (
+                <RunningHotRunnersEditor
+                    component={component}
+                    onChange={onChange}
+                />
+            );
+        case "Trackers":
+            return <TrackersEditor component={component} onChange={onChange} />;
+        case "LightLevel":
+            return (
+                <LightLevelEditor component={component} onChange={onChange} />
+            );
+    }
+}
+
+/**
+ * Structural editor for a game's components: which ones exist, and the parts of
+ * them that no other screen can change.
+ *
+ * Deliberately not a value-setting UI. Live values - defcon statuses, tracker
+ * values, share prices, the weather message, the light level - all have
+ * dedicated endpoints and controls under `/game/[id]/control`, and the control
+ * desk is where an operator changes them mid-game. What is *only* reachable
+ * here is structure: adding or removing a component, tracker names and maxima,
+ * the defcon country roster, the runner roster, and the wolf-attack alert text.
+ */
+export function ComponentsEditor({
+    components,
+    onChange,
+}: {
+    components: Component[];
+    onChange: (components: Component[]) => void;
+}) {
+    const present = new Set(components.map((val) => val.componentType));
+
+    // The app assumes at most one component of each type: `findComponent` in
+    // src/server/components.ts takes the *first* match, so a second of the same
+    // type would be invisible to every control route. Don't offer it.
+    const available = COMPONENT_TYPES.filter((type) => !present.has(type));
+
+    const [newType, setNewType] = useState<ComponentType>("Defcon");
+
+    // Typed as possibly-undefined so that "nothing left to add" is the same
+    // condition as "no type to select", narrowed by one branch below rather than
+    // relying on a separate length check to keep `available[0]` honest.
+    const fallback: ComponentType | undefined = available[0];
+    const selectedType: ComponentType | undefined = available.includes(newType)
+        ? newType
+        : fallback;
+
+    return (
+        <div className="flex flex-col gap-4">
+            {components.length == 0 ? (
+                <p className="text-sm text-zinc-500">
+                    This game has no components. Add one below if you need any.
+                </p>
+            ) : null}
+            {components.map((component, index) => (
+                <div
+                    key={component.componentType}
+                    className="rounded-lg border border-zinc-700 bg-zinc-900/60 p-4"
+                >
+                    <div className="mb-3 flex items-center justify-between">
+                        <h3 className="text-sm font-semibold text-zinc-200">
+                            {COMPONENT_LABELS[component.componentType]}
+                        </h3>
+                        <button
+                            type="button"
+                            className={REMOVE_BUTTON_CLASSES}
+                            onClick={() =>
+                                onChange(
+                                    components.filter((_, i) => i !== index),
+                                )
+                            }
+                        >
+                            Remove {COMPONENT_LABELS[component.componentType]}
+                        </button>
+                    </div>
+                    <ComponentEditor
+                        component={component}
+                        onChange={(updated) =>
+                            onChange(
+                                components.map((existing, i) =>
+                                    i === index ? updated : existing,
+                                ),
+                            )
+                        }
+                    />
+                </div>
+            ))}
+            {selectedType === undefined ? (
+                <p className="text-sm text-zinc-500">
+                    Every component type is already on this game.
+                </p>
+            ) : (
+                <div className="flex items-end gap-2">
+                    <div className="grow">
+                        <label
+                            className={FIELD_LABEL_CLASSES}
+                            htmlFor="new-component-type"
+                        >
+                            Component type
+                        </label>
+                        <select
+                            id="new-component-type"
+                            className={`mt-1 ${INPUT_CLASSES}`}
+                            value={selectedType}
+                            onChange={(event) =>
+                                setNewType(event.target.value as ComponentType)
+                            }
+                        >
+                            {available.map((type) => (
+                                <option key={type} value={type}>
+                                    {COMPONENT_LABELS[type]}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <button
+                        type="button"
+                        className={ADD_BUTTON_CLASSES}
+                        onClick={() =>
+                            onChange([
+                                ...components,
+                                defaultComponent(selectedType),
+                            ])
+                        }
+                    >
+                        Add component
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
Closes #821. Phase 5 of seven in #816.

## Why

The forthcoming edit-a-game form needs bespoke sub-forms for all seven component variants. **#775 already built exactly that** for the create-game flow. This ports it to `src/components/admin/` so both forms can use it, and lands it separately so the edit-form PR stays reviewable rather than becoming a ~1,500 line diff.

**Nothing imports it yet.**

## What it is

One controlled `{components, onChange}` interface over sub-forms for all seven variants: Defcon (country roster plus flag/name/status), Weather, `DoWWolfAttack` (in-progress flag and the optional custom alert), `RunningHotCorp`, `RunningHotRunners` (runner roster, gang, rep), Trackers (add/remove, style/value/max) and LightLevel.

**Deliberately structural, not value-setting.** Live values all have dedicated endpoints and controls under `/game/[id]/control`, and that's where an operator changes them mid-game — `ControlTrackers` even has its own add/delete-tracker form already. What's *only* reachable here is structure: which components exist, tracker names and maxima, the country and runner rosters, and the alert text. The docblock on `ComponentsEditor` says so, to stop this drifting into a duplicate control desk.

## Adapted to current `main`, not copied

#775 is based on stale `main`, so this is a port rather than a cherry-pick:

- `ComponentOfType` is imported from `src/server/components.ts` rather than redeclared locally, so the two can't drift. It's `import type`, which is erased at compile time and therefore can't drag server code into the client bundle — worth the comment it has, since a plain import there would be a real bug.
- #775's `gameTemplates.ts` is **not** ported; `main` already has `GAME_DEFINITIONS`.

## Two additions on top of #775's version

**The add dropdown only offers types the game doesn't already have.** `findComponent` (`src/server/components.ts`) takes the *first* match, so the app assumes one component per type — a second would be silently unreachable from every control route. Once all seven are present the control is replaced with a note rather than left in a dead state.

**New country / runner / tracker names are validated at the point of entry**, with the same `isUnsafeKey` guard the tracker control route applies server-side, so the operator gets the error while typing rather than on save. Duplicates are rejected with `Object.hasOwn` rather than `in` — `in` also matches inherited members, so `"toString"` would have read as a duplicate of something that was never added. The docblock on `isUnsafeKey` makes exactly this point.

One smaller fix folded in: clearing a custom wolf alert rebuilds the component **without** the key rather than setting it to `undefined`. `alert` is optional in the codec, and an explicit `undefined` would be persisted by Mongo as a `null` that then fails to decode on the way back.

## Tests

`__test__/components/ComponentsEditor.test.tsx` — 44 cases, using `fireEvent` rather than adding `@testing-library/user-event` (not currently a dependency).

The load-bearing ones assert that **everything the editor can emit satisfies `ComponentDecode`** — the codec the edit API will validate against, so an editor capable of producing something the API rejects is a broken editor. That covers every `defaultComponent`, the `"hidden"`-vs-number Defcon status union, a non-numeric tracker value coercing to `0` rather than `NaN`, and the custom-alert shape.

Also covered: add/remove/edit for each roster; the dropdown omitting present types and disappearing when all seven are in; the selection falling back to an available type after the selected one is added; unsafe and duplicate names blocked with a `role="alert"` message and no `onChange`; and the alert key being dropped rather than nulled.

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 44 suites / 718 tests passing (43 / 674 before, +1 suite / +44)
- `npx prettier --check` — clean

## Follow-up

Once this merges, #775 should drop its local `ComponentsEditor.tsx` and import the shared one as part of the rebase it already needs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9)_