### PR TITLE
feat(game): reload open screens when a game has been edited

### DIFF
--- a/__test__/components/GameWrapper.test.tsx
+++ b/__test__/components/GameWrapper.test.tsx
@@ -7,7 +7,7 @@ import {
     jest,
     test,
 } from "@jest/globals";
-import { act, render } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { ApiResponse, Game, SetupInformation } from "@fc/types/types";
 import {
     makeActiveGame,
@@ -32,13 +32,51 @@ jest.mock("@fc/lib/useInterval", () => ({
 // in browser APIs jsdom can't provide); we only care about the poll interval.
 // Mocking the registry rather than each theme keeps the theme selection out of
 // these tests and avoids the async next/dynamic loadable entirely.
+//
+// The stand-in still renders `childComponent`, because that is where the control
+// and press tools live and one of the tests below drives a control action.
 jest.mock("@fc/components/theme/registry", () => ({
     __esModule: true,
     THEME_REGISTRY: new Proxy(
         {},
         {
-            get: () => () => null,
+            get:
+                () =>
+                ({ childComponent }: { childComponent: React.ReactNode }) => (
+                    <>{childComponent}</>
+                ),
         },
+    ),
+}));
+
+// window.location.reload cannot be spied on in jsdom (Location's members are
+// [LegacyUnforgeable], so both jest.spyOn and defineProperty throw), which is
+// why GameWrapper goes through this module.
+jest.mock("@fc/lib/reload", () => ({
+    __esModule: true,
+    hardReload: jest.fn(),
+}));
+
+// ControlTools is stubbed to a button that hands a response straight back, so we
+// can prove the edit check also covers the mutation paths - not just the poll.
+const controlResponse: { current: ApiResponse | null } = { current: null };
+jest.mock("@fc/components/ControlTools", () => ({
+    __esModule: true,
+    default: ({
+        setApiResponse,
+    }: {
+        setApiResponse: (apiResponse: ApiResponse) => void;
+    }) => (
+        <button
+            type="button"
+            onClick={() => {
+                if (controlResponse.current !== null) {
+                    setApiResponse(controlResponse.current);
+                }
+            }}
+        >
+            fake control action
+        </button>
     ),
 }));
 
@@ -46,11 +84,17 @@ jest.mock("@fc/components/theme/registry", () => ({
 // registered - the repo's established pattern (see __test__/app/game/api.test.ts).
 type GameWrapperModule = typeof import("../../src/app/game/[id]/GameWrapper");
 let GameWrapper: GameWrapperModule["default"];
+let hardReload: jest.Mock<() => void>;
 
 beforeAll(async () => {
     ({ default: GameWrapper } =
         await import("../../src/app/game/[id]/GameWrapper"));
+    ({ hardReload } = (await import("@fc/lib/reload")) as never);
 });
+
+// Records every chime attempt so a "did not play" assertion can't pass because
+// the stub was never wired up.
+const audioPlay = jest.fn(() => Promise.resolve());
 
 // The default fixture's phaseEnd is in the past, so toApiResponse yields
 // phaseEnd === 0 - exactly the condition that used to collapse the poll
@@ -77,6 +121,22 @@ function pollDelays(): (number | null)[] {
     return mockIntervalDelays.filter((_, index) => index % 2 === 0);
 }
 
+/**
+ * The poll callback from the most recent render.
+ *
+ * Not `mockIntervalCallbacks[0]`: that closure is from the very first render,
+ * before the effect that constructs the Audio element has run, so `audio` is
+ * still undefined inside it and the turn-change chime can never fire. Tests that
+ * care about the chime have to drive the latest closure.
+ */
+function latestPoll(): () => void {
+    const polls = mockIntervalCallbacks.filter((_, index) => index % 2 === 0);
+    const poll = polls.at(-1);
+
+    expect(poll).toBeDefined();
+    return poll as () => void;
+}
+
 describe("GameWrapper poll interval", () => {
     beforeEach(() => {
         mockIntervalDelays.length = 0;
@@ -86,10 +146,9 @@ describe("GameWrapper poll interval", () => {
         jest.spyOn(Math, "random").mockReturnValue(0.5);
         // jsdom doesn't implement media playback; GameWrapper constructs an
         // Audio element in an effect, so provide a harmless stub.
+        audioPlay.mockClear();
         (window as unknown as { Audio: unknown }).Audio = class {
-            play() {
-                return Promise.resolve();
-            }
+            play = audioPlay;
         };
     });
 
@@ -185,5 +244,199 @@ describe("GameWrapper poll interval", () => {
         // the poll interval off to the slow cadence - proving it is not frozen
         // at its mount value.
         expect(pollDelays().at(-1)).toBe(33750);
+    });
+});
+
+describe("GameWrapper reload-on-edit", () => {
+    // `setupInformation` (phase names/lengths, theme, press config) comes from the
+    // server-rendered `game` prop and is never refreshed by polling, so a full
+    // document load is the only way an admin edit reaches an open screen.
+    // GameWrapper compares each response's stamp against the one it rendered
+    // with; these tests pin the comparison and its side effects.
+    function makeBody(overrides: Partial<ApiResponse> = {}): ApiResponse {
+        return {
+            turnNumber: 1,
+            phase: 1,
+            breakingNews: [],
+            active: true,
+            phaseEnd: 30,
+            lastUpdated: 0,
+            components: [],
+            ...overrides,
+        };
+    }
+
+    function mockPoll(body: ApiResponse) {
+        (global as unknown as { fetch: unknown }).fetch = jest.fn(() =>
+            Promise.resolve({ json: () => Promise.resolve(body) }),
+        );
+    }
+
+    beforeEach(() => {
+        mockIntervalDelays.length = 0;
+        mockIntervalCallbacks.length = 0;
+        controlResponse.current = null;
+        hardReload.mockClear();
+        jest.spyOn(Math, "random").mockReturnValue(0.5);
+        audioPlay.mockClear();
+        (window as unknown as { Audio: unknown }).Audio = class {
+            play = audioPlay;
+        };
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("reloads when the poll reports a newer stamp", async () => {
+        mockPoll(makeBody({ lastUpdated: 1_700_000_000_000 }));
+
+        render(<GameWrapper game={makeActiveGame()} mode="Player" />);
+
+        await act(async () => {
+            latestPoll()();
+        });
+
+        expect(hardReload).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not reload when the stamp is unchanged", async () => {
+        // Strict `>`: an equal stamp is the normal case on every single poll, so
+        // a `>=` here would reload every device forever.
+        mockPoll(makeBody({ lastUpdated: 500 }));
+
+        render(
+            <GameWrapper
+                game={makeActiveGame({ lastUpdated: 500 })}
+                mode="Player"
+            />,
+        );
+
+        await act(async () => {
+            latestPoll()();
+        });
+
+        expect(hardReload).not.toHaveBeenCalled();
+    });
+
+    test("does not reload when the stamp goes backwards", async () => {
+        // Clock skew or a lagging replica should not trigger anything.
+        mockPoll(makeBody({ lastUpdated: 100 }));
+
+        render(
+            <GameWrapper
+                game={makeActiveGame({ lastUpdated: 5000 })}
+                mode="Player"
+            />,
+        );
+
+        await act(async () => {
+            latestPoll()();
+        });
+
+        expect(hardReload).not.toHaveBeenCalled();
+    });
+
+    test("reloads a game that had no stamp before it was edited", async () => {
+        // Most games predate the field, so this is the common first-edit path. A
+        // "no baseline, do nothing" guard would break exactly this case.
+        const game = makeActiveGame();
+        expect(game.lastUpdated).toBeUndefined();
+
+        mockPoll(makeBody({ lastUpdated: 1 }));
+
+        render(<GameWrapper game={game} mode="Player" />);
+
+        await act(async () => {
+            latestPoll()();
+        });
+
+        expect(hardReload).toHaveBeenCalledTimes(1);
+    });
+
+    test("plays the chime on a turn change with an unchanged stamp", async () => {
+        // The control for the test below: proves the chime does fire here, so
+        // "did not play" there is a real assertion rather than a broken stub.
+        mockPoll(makeBody({ turnNumber: 2, lastUpdated: 0 }));
+
+        render(<GameWrapper game={makeActiveGame()} mode="Player" />);
+
+        await act(async () => {
+            latestPoll()();
+        });
+
+        expect(hardReload).not.toHaveBeenCalled();
+        expect(audioPlay).toHaveBeenCalled();
+    });
+
+    test("does not play the chime when it is reloading", async () => {
+        // An edit response can carry a new turn number too (the phase gets
+        // recomputed), and that is not a turn change the players should hear.
+        mockPoll(makeBody({ turnNumber: 2, lastUpdated: 1_700_000_000_000 }));
+
+        render(<GameWrapper game={makeActiveGame()} mode="Player" />);
+
+        await act(async () => {
+            latestPoll()();
+        });
+
+        expect(hardReload).toHaveBeenCalledTimes(1);
+        expect(audioPlay).not.toHaveBeenCalled();
+    });
+
+    test("does not adopt the response when it is reloading", async () => {
+        // Applying a fresh phase against the stale phase list is what both themes
+        // throw on, so the poll must return before setAPIResponse. Observed via
+        // the poll cadence, which is derived from apiResponse: the finished body
+        // would back it off to 33750 if it had been applied.
+        const finishedish = makeBody({
+            turnNumber: 1,
+            phase: finishedSetup.phases.length,
+            phaseEnd: 0,
+            lastUpdated: 1_700_000_000_000,
+        });
+        mockPoll(finishedish);
+
+        render(
+            <GameWrapper
+                game={makeActiveGame({
+                    setupInformation: finishedSetup,
+                    turnInformation: {
+                        turnNumber: 1,
+                        currentPhase: 1,
+                        phaseEnd: new Date(2023, 1, 2, 3, 5, 10, 0).toString(),
+                    },
+                })}
+                mode="Player"
+            />,
+        );
+
+        expect(pollDelays().at(-1)).toBe(5625);
+
+        await act(async () => {
+            latestPoll()();
+        });
+
+        expect(hardReload).toHaveBeenCalledTimes(1);
+        // Still the active cadence: the response never reached state.
+        expect(pollDelays().at(-1)).toBe(5625);
+    });
+
+    test("also checks responses that come back from a control action", async () => {
+        // The control desk, the seven component controls and the press form all
+        // adopt a server ApiResponse directly. They go through the same funnel, so
+        // whichever screen acts first picks up the edit.
+        mockPoll(makeBody());
+        controlResponse.current = makeBody({ lastUpdated: 1_700_000_000_000 });
+
+        render(<GameWrapper game={makeActiveGame()} mode="Control" />);
+
+        expect(hardReload).not.toHaveBeenCalled();
+
+        await act(async () => {
+            screen.getByRole("button", { name: "fake control action" }).click();
+        });
+
+        expect(hardReload).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/app/game/[id]/GameWrapper.tsx
+++ b/src/app/game/[id]/GameWrapper.tsx
@@ -8,6 +8,7 @@ import { ApiResponseDecode } from "@fc/types/io-ts-def";
 import ControlTools from "@fc/components/ControlTools";
 import PressForm from "./press/PressForm";
 import { DEFAULT_THEME, THEME_REGISTRY } from "@fc/components/theme/registry";
+import { hardReload } from "@fc/lib/reload";
 
 const triggersAudio: (keyof ApiResponse)[] = ["active", "turnNumber", "phase"];
 
@@ -27,6 +28,14 @@ export default function GameWrapper(props: GameWrapperProps) {
     const [apiResponse, setAPIResponse] = useState<ApiResponse>(
         toApiResponse(game),
     );
+
+    // Everything in `setupInformation` - phase titles and lengths, the theme,
+    // press accounts, logos, maxTurns, timerStyles - comes from the `game` prop
+    // that was server-rendered once, and polling only ever refreshes
+    // `ApiResponse`. So an admin edit cannot reach this screen at all without a
+    // full document load. Pin the document version this render was built from; a
+    // lazy initialiser keeps it stable instead of drifting with `game`.
+    const [renderedAt] = useState<number>(() => game.lastUpdated ?? 0);
 
     const [audio, setAudio] = useState<HTMLAudioElement>();
 
@@ -65,6 +74,34 @@ export default function GameWrapper(props: GameWrapperProps) {
         1000,
         Math.round(basePollDelay * (1 + jitterFactor * 0.25)),
     );
+
+    /**
+     * Adopt a server response, unless the game has been edited underneath us - in
+     * which case reload instead and report false.
+     *
+     * Every path that takes a server `ApiResponse` goes through here: the poll,
+     * the control buttons, the seven component controls and the press form. Any
+     * of them can be the first to see an edit, and funnelling them means the
+     * child components need no changes.
+     *
+     * Strict `>`, never `>=`: after the reload `renderedAt` is re-seeded from the
+     * fresh render and equals the served stamp, so the condition goes false.
+     * `>=` would reload forever. There is deliberately no "no baseline" guard
+     * either - `lastUpdated` is read from the game document rather than the
+     * frozen snapshot, so an unedited game reports 0 on both sides consistently,
+     * and a guard would suppress the reload for the first edit of every game
+     * that predates the field.
+     */
+    const applyApiResponse = (body: ApiResponse): boolean => {
+        if (body.lastUpdated > renderedAt) {
+            hardReload();
+            return false;
+        }
+
+        setAPIResponse(body);
+        return true;
+    };
+
     useInterval(() => {
         if (fetching) {
             return;
@@ -79,7 +116,16 @@ export default function GameWrapper(props: GameWrapperProps) {
             .then((response) => response.json())
             .then((body) => {
                 if (ApiResponseDecode.is(body)) {
-                    setAPIResponse(body);
+                    if (!applyApiResponse(body)) {
+                        // Reloading. Returning here matters twice over: we must
+                        // not touch state we're about to tear down, and we must
+                        // not render a fresh `phase` against the stale phase
+                        // list, which both themes throw on when the phase is out
+                        // of range. It also stops the turn-change chime firing -
+                        // an edit response can carry a new turn number, and that
+                        // is not a turn change the players should hear.
+                        return;
+                    }
 
                     if (
                         triggersAudio.some(
@@ -120,7 +166,7 @@ export default function GameWrapper(props: GameWrapperProps) {
                 <ControlTools
                     game={game}
                     apiResponse={apiResponse}
-                    setApiResponse={setAPIResponse}
+                    setApiResponse={applyApiResponse}
                 />
             );
             manageTabTitle = "Control Tools";
@@ -130,7 +176,7 @@ export default function GameWrapper(props: GameWrapperProps) {
                 <PressForm
                     game={game}
                     apiResponse={apiResponse}
-                    setApiResponse={setAPIResponse}
+                    setApiResponse={applyApiResponse}
                     pressAccount={props.pressAccount}
                 />
             );

--- a/src/app/game/[id]/control/page.tsx
+++ b/src/app/game/[id]/control/page.tsx
@@ -4,6 +4,14 @@ import { isLeft } from "fp-ts/Either";
 import GameWrapper from "../GameWrapper";
 import { notFound } from "next/navigation";
 
+// A hard reload is how an admin edit reaches an already-open screen (see
+// GameWrapper), so this page must read the live database on every request. Next
+// treats a dynamic segment with no generateStaticParams as static-eligible, and
+// the Mongo read goes through the driver rather than `fetch`, so the framework
+// has no cache key to invalidate. A cached shell would make the reload a no-op
+// and, because the stamp would never advance, loop forever.
+export const dynamic = "force-dynamic";
+
 export default async function Page(props: { params: Promise<{ id: string }> }) {
     const params = await props.params;
     const gameRepo = getGameRepo();

--- a/src/app/game/[id]/page.tsx
+++ b/src/app/game/[id]/page.tsx
@@ -4,6 +4,14 @@ import { isLeft } from "fp-ts/Either";
 import GameWrapper from "./GameWrapper";
 import { notFound } from "next/navigation";
 
+// A hard reload is how an admin edit reaches an already-open screen (see
+// GameWrapper), so this page must read the live database on every request. Next
+// treats a dynamic segment with no generateStaticParams as static-eligible, and
+// the Mongo read goes through the driver rather than `fetch`, so the framework
+// has no cache key to invalidate. A cached shell would make the reload a no-op
+// and, because the stamp would never advance, loop forever.
+export const dynamic = "force-dynamic";
+
 export default async function Page(props: { params: Promise<{ id: string }> }) {
     const params = await props.params;
     const gameRepo = getGameRepo();

--- a/src/app/game/[id]/press/[account]/page.tsx
+++ b/src/app/game/[id]/press/[account]/page.tsx
@@ -5,6 +5,14 @@ import StandardPressPage from "../page";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+// A hard reload is how an admin edit reaches an already-open screen (see
+// GameWrapper), so this page must read the live database on every request. Next
+// treats a dynamic segment with no generateStaticParams as static-eligible, and
+// the Mongo read goes through the driver rather than `fetch`, so the framework
+// has no cache key to invalidate. A cached shell would make the reload a no-op
+// and, because the stamp would never advance, loop forever.
+export const dynamic = "force-dynamic";
+
 export default async function Page(props: {
     params: Promise<{ id: string; account: string }>;
 }) {

--- a/src/app/game/[id]/press/page.tsx
+++ b/src/app/game/[id]/press/page.tsx
@@ -6,6 +6,14 @@ import { getIconForPress } from "@fc/lib/press";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 
+// A hard reload is how an admin edit reaches an already-open screen (see
+// GameWrapper), so this page must read the live database on every request. Next
+// treats a dynamic segment with no generateStaticParams as static-eligible, and
+// the Mongo read goes through the driver rather than `fetch`, so the framework
+// has no cache key to invalidate. A cached shell would make the reload a no-op
+// and, because the stamp would never advance, loop forever.
+export const dynamic = "force-dynamic";
+
 export default async function Page(props: { params: Promise<{ id: string }> }) {
     const params = await props.params;
     const gameRepo = getGameRepo();

--- a/src/lib/reload.ts
+++ b/src/lib/reload.ts
@@ -1,0 +1,22 @@
+/**
+ * Reload the current document.
+ *
+ * A full document load, not a router navigation: the point is to throw away the
+ * server-rendered `game` prop - and with it the whole of `setupInformation` -
+ * and re-render from the database. `router.refresh()` is not enough, because
+ * Next's Router Cache can serve a stale copy; this is the same reasoning behind
+ * `LogoutButton` and `LoginForm` using `window.location.assign`.
+ *
+ * It lives in its own module purely so tests can mock it. `Location`'s members
+ * are `[LegacyUnforgeable]`, so in jsdom `window.location.reload` can be neither
+ * reassigned nor spied on - `jest.spyOn` and
+ * `Object.defineProperty(window, "location", ...)` both throw.
+ *
+ * If a reload stampede ever becomes a problem, this is where a jitter delay
+ * would go. It should not be needed: callers reload from inside the poll
+ * callback, and the poll is already spread across 5-6.25s per device by
+ * `GameWrapper`'s jitter factor, so reloads inherit that spread.
+ */
+export function hardReload(): void {
+    window.location.reload();
+}


### PR DESCRIPTION
Closes #819. Phase 3 of seven in #816.

> **Stacked on #825** (`claude/818-last-updated`), which adds the `lastUpdated` field this consumes. Base is that branch, so the diff here is just the client change; GitHub will retarget to `main` when #825 merges. Review #825 first.

## Why

Every open player, control and press screen receives the whole `Game` as a server-rendered prop and only ever polls `ApiResponse`. Phase titles and lengths, the theme, press accounts, logos and `maxTurns` are therefore fixed for the lifetime of the page — so without this, an edit reaches nobody until they happen to reload.

`GameWrapper` now pins the `lastUpdated` stamp its render was built from and hard-reloads when a response reports a newer one. **Inert until the edit API lands**, since nothing writes the stamp yet.

## One funnel, not nine call sites

Every path that adopts a server response goes through `applyApiResponse`: the poll, the control buttons, the seven component controls, and the press form. Any of them can be the first to see an edit, and funnelling means the child components need no changes at all — `(body: ApiResponse) => boolean` is assignable to their `(apiResponse: ApiResponse) => void` prop under return-type bivariance.

## Two details that are load-bearing, not stylistic

**The check runs before `setAPIResponse` and returns.** Applying a fresh `phase` against the stale phase list is exactly what both themes `throw new Error("Unknown current phase information")` on (`FirstContactTheme.tsx:34`, `AftermathTheme.tsx:35`) — so adding a phase and letting the game advance into it would crash the render rather than reload it. Returning early also suppresses the turn-change chime, because an edit response can carry a new turn number (the phase gets recomputed server-side) and that isn't a turn change the players should hear.

**Strict `>`, and deliberately no "no baseline" guard.** After the reload the stamp is re-seeded from the fresh render and equals the served value, so the condition goes false — `>=` would reload forever. A `renderedAt > 0` guard looks tempting for legacy documents, but because the stamp is read from the game document rather than the frozen snapshot, an unedited game reports `0` on both sides consistently. There's no loop to prevent, and the guard would suppress the reload for the *first* edit of every game that predates the field — which is most of them. There's a test for exactly that case.

## `src/lib/reload.ts`

`hardReload()` wraps `window.location.reload()` in a module rather than calling it inline, because `Location`'s members are `[LegacyUnforgeable]`: in jsdom both `jest.spyOn(window.location, "reload")` and `Object.defineProperty(window, "location", …)` throw, so there is otherwise no way to assert on it. Same spirit as the existing `window.location.assign` in `LogoutButton`/`LoginForm`, and the docblock records where reload jitter would go if a stampede ever became a problem (it shouldn't — reloads fire from inside the poll callback, which is already spread across 5–6.25 s per device).

## `force-dynamic` is belt-and-braces, not a fix

To be clear about this rather than overclaim: **the build already reports all four game pages as dynamic (`ƒ`) without it.** I checked by stashing the change and rebuilding. They're dynamic segments with no `generateStaticParams`, so Next renders them on demand today.

Adding it makes the requirement explicit, because the failure mode if that ever changed is nasty: a prerendered shell would make the reload a no-op *and* the stamp would never advance, so it would loop forever. Four self-documenting lines against a severe regression seemed worth it.

## Tests

Nine new cases in `__test__/components/GameWrapper.test.tsx`, on the existing harness. Two things worth flagging for review:

- **The reload tests drive the latest poll closure, not `mockIntervalCallbacks[0]`.** The first render's closure captures `audio` as `undefined` (it's set in an effect), so the chime can never fire through it — the "does not play the chime while reloading" assertion would have passed vacuously. There's a **positive control** immediately before it proving the chime *does* fire for a plain turn change with an unchanged stamp.
- **The theme registry stand-in now renders `childComponent`**, so a control action can actually be driven through the funnel. Previously it rendered `null` and swallowed the control tools entirely.

Covered: reloads on a newer stamp; doesn't on an equal one (guards a `>=` typo) or an older one (clock skew / replica lag); reloads a game that had no stamp before being edited; doesn't play the chime while reloading; doesn't adopt the response while reloading (observed via the poll cadence, which would have backed off to 33750 had it been applied); and the same check firing for a control-action response.

## Verification

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 43 suites / 687 tests passing (679 on the base branch, +8)
- `npm run build` — compiles; all four game routes listed `ƒ (Dynamic)`
- `npx prettier --check` — clean

Manual check once the edit API exists: set `lastUpdated` on a game directly in Mongo and confirm every open screen reloads within a poll cycle.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9)_