### PR TITLE
chore: gitignore next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@
 # next.js
 /.next/
 /out/
+# Generated output ("This file should not be edited"), and next dev and next
+# build disagree about whether it imports .next/dev/types/routes.d.ts or
+# .next/types/routes.d.ts - so tracking it means a diff that flips depending on
+# which command ran last. Both commands regenerate it before type checking, so
+# nothing needs the committed copy.
+/next-env.d.ts
 
 # production
 /build

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Standalone cleanup, unrelated to #816 — noticed because a verification build in that work left the tree dirty.

## Why

`next-env.d.ts` is generated output. It says so itself:

```
// NOTE: This file should not be edited
```

But it's tracked, and `next dev` and `next build` disagree about its contents:

```diff
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
```

So it shows up as a dirty file that flips back and forth depending on which command you last ran. Committing either version just means the next person flips it back.

## The change

One `.gitignore` entry, and untrack the file. Nothing needs the committed copy: `npm run dev` and `npm run build` both regenerate it before type checking.

## Verification

Deleted `next-env.d.ts` and `.next/` entirely, then:

- `npm run build` — recreates the file, compiles clean
- `npm test` — 43 suites / 674 tests passing
- `npm run lint` — clean
- `npx prettier --check .` (as CI runs it) — clean
- `git status` after the build — clean

That last one is the point: building no longer dirties the tree.

<details>
<summary>An earlier version of this PR also added a committed <code>src/types/next-assets.d.ts</code> — dropped, and why</summary>

The generated file carries `/// <reference types="next/image-types/global" />`, which is what declares the modules for the `.png`/`.svg` imports used across `TabSwitcher`, `RunningHot/helpers`, `lib/press` and the aftermath theme. Without it a bare `npx tsc --noEmit` fails with ~20 `Cannot find module './ANT.png'` errors, so I'd moved those reference directives into a committed file to keep a direct `tsc` working.

That was solving a problem this project doesn't have. Type checking happens through `npm run dev` / `npm run build`, and both regenerate `next-env.d.ts` first — so the committed copy of those references was pure redundancy, plus a second place to keep in sync if Next ever changes its reference list.

The only residual case is a fresh clone where an editor's tsserver (or `npm run ts:watch`) starts before the first `dev`/`build`. It resolves itself the moment either runs, so it's an accepted trade rather than a hidden one.

</details>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdNoXM4v1jCDW1ru2CS4C9